### PR TITLE
fix(frontend): expose NEXT_PUBLIC env vars statically for client bundle

### DIFF
--- a/apps/web/lib/env.ts
+++ b/apps/web/lib/env.ts
@@ -1,14 +1,18 @@
-function getEnvVar(key: string, required = true): string {
-  const value = process.env[key];
-  if (required && !value) {
-    throw new Error(`Missing environment variable: ${key}`);
+const NEXT_PUBLIC_CONVEX_URL = process.env.NEXT_PUBLIC_CONVEX_URL;
+const NEXT_PUBLIC_MAPBOX_TOKEN = process.env.NEXT_PUBLIC_MAPBOX_TOKEN;
+const ORS_API_KEY = process.env.ORS_API_KEY;
+const GOOGLE_PLACES_API_KEY = process.env.GOOGLE_PLACES_API_KEY;
+
+function getRequired(name: string, value: string | undefined): string {
+  if (!value) {
+    throw new Error(`Missing environment variable: ${name}`);
   }
-  return value ?? "";
+  return value;
 }
 
 export const env = {
-  CONVEX_URL: getEnvVar("NEXT_PUBLIC_CONVEX_URL"),
-  MAPBOX_TOKEN: getEnvVar("NEXT_PUBLIC_MAPBOX_TOKEN", false),
-  ORS_API_KEY: getEnvVar("ORS_API_KEY", false),
-  GOOGLE_PLACES_API_KEY: getEnvVar("GOOGLE_PLACES_API_KEY", false),
+  CONVEX_URL: getRequired("NEXT_PUBLIC_CONVEX_URL", NEXT_PUBLIC_CONVEX_URL),
+  MAPBOX_TOKEN: NEXT_PUBLIC_MAPBOX_TOKEN ?? "",
+  ORS_API_KEY: ORS_API_KEY ?? "",
+  GOOGLE_PLACES_API_KEY: GOOGLE_PLACES_API_KEY ?? "",
 } as const;


### PR DESCRIPTION
## Contexte

Le déploiement Vercel échoue avec une erreur `Missing environment variable: NEXT_PUBLIC_CONVEX_URL` alors même que la variable est bien configurée dans Vercel.

## Cause

Le helper `lib/env.ts` utilise un accès dynamique `process.env[key]`. Next.js ne réécrit statiquement que les références littérales `process.env.NEXT_PUBLIC_*` ; un accès dynamique n'est pas remplacé au build, donc le bundle client voit `undefined`.

## Fix

`env.ts` réécrit pour lire chaque variable via un accès statique direct, puis exposer le helper `getRequired()` pour les variables obligatoires. Aucun changement d'API publique : `env.CONVEX_URL`, `env.MAPBOX_TOKEN`, etc. restent identiques.

## Test

Build local OK, déploiement Vercel attendu après merge.