### PR TITLE
fix(frontend): apply className to map container wrapper

### DIFF
--- a/apps/web/components/map/map-container.tsx
+++ b/apps/web/components/map/map-container.tsx
@@ -109,7 +109,7 @@ export const MapContainer = forwardRef<MapContainerHandle, MapContainerProps>(
   }
 
   return (
-    <div aria-label="Carte interactive" role="region">
+    <div aria-label="Carte interactive" role="region" className={className}>
       <span className="sr-only">
         Carte interactive affichant les positions des participants et lieux de rendez-vous
       </span>


### PR DESCRIPTION
## Contexte

La carte ne s'affiche pas sur le déploiement Vercel : le conteneur reste vide même si la `<Map>` se monte.

## Cause

Dans `map-container.tsx`, le prop `className` (qui contient le défaut `h-full w-full`) n'est pas appliqué au `<div>` wrapper. La `<Map>` à l'intérieur s'étire à 100 % d'un parent sans dimensions, donc dimensions zéro et rien à l'écran.

## Fix

Ajout de `className={className}` sur le `<div>` wrapper. La hauteur est désormais portée correctement et la carte s'affiche.

## Test

Build local OK. À vérifier sur le déploiement Vercel après merge.