### PR TITLE
fix(frontend): chosen AI city drives routes and map destination

### DIFF
--- a/apps/web/app/meet/[id]/page.tsx
+++ b/apps/web/app/meet/[id]/page.tsx
@@ -23,7 +23,7 @@ const PlacesList = dynamic(
   () => import("@/components/places-list").then((m) => ({ default: m.PlacesList })),
   { ssr: false }
 );
-import { calculateMidpointWithMetrics } from "@meetpoint/geo";
+import { calculateMidpointWithMetrics, calculateMetricsForPoint } from "@meetpoint/geo";
 import { api } from "../../../../../convex/_generated/api";
 import type { Id, Doc } from "../../../../../convex/_generated/dataModel";
 
@@ -110,10 +110,10 @@ interface RouteData {
   error?: string;
 }
 
-interface SelectedCity {
+type SelectedCity = {
   name: string;
   coordinates: { lat: number; lng: number };
-}
+};
 
 export default function MeetPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params);
@@ -189,23 +189,31 @@ export default function MeetPage({ params }: { params: Promise<{ id: string }> }
       coordinates: city.coordinates,
     };
     setSelectedCity(nextSelection);
+    setRoutes([]);
     mapRef.current?.flyTo(city.coordinates, 12);
     await selectCity({ meetId, selectedCity: nextSelection });
   };
 
+  const participantLocations = participants?.map((p: Doc<"participants">) => p.location) ?? [];
+
+  const midpointResult =
+    participantLocations.length >= 2 ? calculateMidpointWithMetrics(participantLocations) : null;
+
+  const effectiveDestination = selectedCity?.coordinates ?? midpointResult?.midpoint ?? null;
+
+  const effectiveMetrics =
+    selectedCity && participantLocations.length >= 2
+      ? calculateMetricsForPoint(selectedCity.coordinates, participantLocations)
+      : midpointResult;
+
   const handleFitAllParticipants = () => {
     if (!participants || participants.length === 0) return;
     const locations = participants.map((p: Doc<"participants">) => p.location);
-    if (midpointResult) {
-      locations.push(midpointResult.midpoint);
+    if (effectiveDestination) {
+      locations.push(effectiveDestination);
     }
     mapRef.current?.fitBounds(locations, 80);
   };
-
-  const midpointResult =
-    participants && participants.length >= 2
-      ? calculateMidpointWithMetrics(participants.map((p: Doc<"participants">) => p.location))
-      : null;
 
   const handleRecalculate = async () => {
     if (!midpointResult) return;
@@ -219,14 +227,14 @@ export default function MeetPage({ params }: { params: Promise<{ id: string }> }
   };
 
   const handleCalculateRoutes = async () => {
-    if (!midpointResult) return;
+    if (!effectiveDestination) return;
 
     setIsCalculatingRoutes(true);
     try {
       const result = await calculateAllRoutes({
         meetId,
-        midpointLat: midpointResult.midpoint.lat,
-        midpointLng: midpointResult.midpoint.lng,
+        midpointLat: effectiveDestination.lat,
+        midpointLng: effectiveDestination.lng,
       });
 
       if (result.success) {
@@ -356,8 +364,8 @@ export default function MeetPage({ params }: { params: Promise<{ id: string }> }
           {participants && participants.length > 0 ? (
             <ul className="space-y-2">
               {participants.map((p: Doc<"participants">, i: number) => {
-                const googleMapsUrl = midpointResult
-                  ? `https://www.google.com/maps/dir/?api=1&origin=${p.location.lat},${p.location.lng}&destination=${midpointResult.midpoint.lat},${midpointResult.midpoint.lng}&travelmode=${p.transportMode === "transit" ? "transit" : p.transportMode}`
+                const googleMapsUrl = effectiveDestination
+                  ? `https://www.google.com/maps/dir/?api=1&origin=${p.location.lat},${p.location.lng}&destination=${effectiveDestination.lat},${effectiveDestination.lng}&travelmode=${p.transportMode === "transit" ? "transit" : p.transportMode}`
                   : null;
 
                 return (
@@ -442,7 +450,7 @@ export default function MeetPage({ params }: { params: Promise<{ id: string }> }
         </div>
 
         {/* Midpoint Stats */}
-        {midpointResult && (
+        {effectiveMetrics && (
           <div className="border-keria-forest/30 bg-keria-forest/10 mb-6 rounded border p-4">
             <h2 className="border-keria-gold text-keria-muted mb-3 border-l-2 pl-3 text-xs font-medium uppercase tracking-wider">
               Point de rencontre
@@ -451,7 +459,7 @@ export default function MeetPage({ params }: { params: Promise<{ id: string }> }
               <div>
                 <p className="text-keria-muted text-[10px] uppercase tracking-wider">Équité</p>
                 <p className="font-display text-keria-gold text-3xl font-bold">
-                  {midpointResult.fairnessScore}%
+                  {effectiveMetrics.fairnessScore}%
                 </p>
               </div>
               <div>
@@ -459,7 +467,7 @@ export default function MeetPage({ params }: { params: Promise<{ id: string }> }
                   Distance moy.
                 </p>
                 <p className="font-display text-keria-cream text-3xl font-bold">
-                  {midpointResult.averageDistanceKm} <span className="text-lg">km</span>
+                  {effectiveMetrics.averageDistanceKm} <span className="text-lg">km</span>
                 </p>
               </div>
             </div>
@@ -580,10 +588,10 @@ export default function MeetPage({ params }: { params: Promise<{ id: string }> }
             />
           ))}
 
-          {midpointResult && (
+          {effectiveDestination && effectiveMetrics && (
             <MapMidpoint
-              coordinates={midpointResult.midpoint}
-              fairnessScore={midpointResult.fairnessScore}
+              coordinates={effectiveDestination}
+              fairnessScore={effectiveMetrics.fairnessScore}
             />
           )}
         </MapContainer>

--- a/packages/geo/src/midpoint.ts
+++ b/packages/geo/src/midpoint.ts
@@ -1,5 +1,10 @@
 import type { Coordinates } from "@meetpoint/types";
-import { degreesToRadians, radiansToDegrees, distanceStandardDeviation, haversineDistance } from "./distance";
+import {
+  degreesToRadians,
+  radiansToDegrees,
+  distanceStandardDeviation,
+  haversineDistance,
+} from "./distance";
 
 export function calculateGeographicCenter(points: Coordinates[]): Coordinates {
   if (points.length === 0) {
@@ -38,10 +43,7 @@ export function calculateGeographicCenter(points: Coordinates[]): Coordinates {
   };
 }
 
-export function calculateWeightedMidpoint(
-  points: Coordinates[],
-  weights: number[]
-): Coordinates {
+export function calculateWeightedMidpoint(points: Coordinates[], weights: number[]): Coordinates {
   if (points.length !== weights.length) {
     throw new Error("Le nombre de points et de poids doit être identique");
   }
@@ -110,22 +112,27 @@ export function optimizeMeetingPoint(
   return bestPoint;
 }
 
-export type MidpointResult = {
-  midpoint: Coordinates;
+export type PointMetrics = {
   fairnessScore: number;
   averageDistanceKm: number;
   maxDistanceKm: number;
 };
 
-export function calculateMidpointWithMetrics(participants: Coordinates[]): MidpointResult {
+export type MidpointResult = PointMetrics & {
+  midpoint: Coordinates;
+};
+
+export function calculateMetricsForPoint(
+  point: Coordinates,
+  participants: Coordinates[]
+): PointMetrics {
   if (participants.length < 2) {
     throw new Error("Au moins 2 participants sont requis");
   }
 
-  const midpoint = optimizeMeetingPoint(participants);
-  const stdDev = distanceStandardDeviation(midpoint, participants);
+  const stdDev = distanceStandardDeviation(point, participants);
 
-  const distances = participants.map((p) => haversineDistance(midpoint, p));
+  const distances = participants.map((p) => haversineDistance(point, p));
   const avgDistance = distances.reduce((a, b) => a + b, 0) / distances.length;
   const maxDistance = Math.max(...distances);
 
@@ -133,9 +140,21 @@ export function calculateMidpointWithMetrics(participants: Coordinates[]): Midpo
   const fairnessScore = Math.max(0, Math.min(100, 100 * (1 - cv)));
 
   return {
-    midpoint,
     fairnessScore: Math.round(fairnessScore),
     averageDistanceKm: Math.round(avgDistance * 10) / 10,
     maxDistanceKm: Math.round(maxDistance * 10) / 10,
+  };
+}
+
+export function calculateMidpointWithMetrics(participants: Coordinates[]): MidpointResult {
+  if (participants.length < 2) {
+    throw new Error("Au moins 2 participants sont requis");
+  }
+
+  const midpoint = optimizeMeetingPoint(participants);
+
+  return {
+    midpoint,
+    ...calculateMetricsForPoint(midpoint, participants),
   };
 }


### PR DESCRIPTION
## Summary
- Selecting an AI-suggested city did not update the trajets or the map; routes and markers still pointed at the geometric midpoint
- The chosen city now drives every destination-dependent output

## Changes
- meet/[id]/page.tsx: derive a single effective destination (selected city, else geometric midpoint) used for trajets, the Google Maps link, fit-bounds and the midpoint marker; clear stale routes when a city is selected
- geo/midpoint.ts: recompute the equity score for the chosen city via calculateMetricsForPoint
- No backend changes

## Test plan
- [ ] Open a meet, select an AI-suggested city, confirm trajets recompute toward it
- [ ] Confirm the map marker, fit-bounds and Google Maps link target the chosen city
- [ ] Confirm the equity score updates for the chosen city
- [ ] Confirm previously displayed routes are cleared on selection