### PR TITLE
fix(frontend): meet sidebar fills full height on desktop

### DIFF
--- a/apps/web/app/meet/[id]/page.tsx
+++ b/apps/web/app/meet/[id]/page.tsx
@@ -283,7 +283,7 @@ export default function MeetPage({ params }: { params: Promise<{ id: string }> }
       <PageBackground />
 
       {/* Sidebar */}
-      <aside className="border-keria-forest/20 bg-keria-darker relative z-10 max-h-[50vh] w-full overflow-y-auto border-b p-5 lg:h-screen lg:w-[380px] lg:overflow-y-auto lg:border-b-0 lg:border-r">
+      <aside className="border-keria-forest/20 bg-keria-darker relative z-10 max-h-[50vh] w-full overflow-y-auto border-b p-5 lg:h-screen lg:max-h-none lg:w-[380px] lg:overflow-y-auto lg:border-b-0 lg:border-r">
         {/* Header */}
         <div className="mb-6 flex items-center justify-between">
           <Link


### PR DESCRIPTION
## Summary
- On desktop the meet sidebar only reached 50vh, leaving an empty black gap at the bottom
- Restores the intended full-height sidebar layout on large screens

## Changes
- apps/web/app/meet/[id]/page.tsx: add `lg:max-h-none` to cancel the mobile `max-h-[50vh]` cap so `lg:h-screen` can fill the viewport

## Test plan
- [ ] Open a meet page on a desktop viewport and confirm the sidebar spans the full height with no bottom gap
- [ ] Confirm mobile still caps the sidebar at 50vh