### PR TITLE
fix(geo): scale midpoint search to spread, fix getMatrix indices

### DIFF
--- a/packages/geo/src/__tests__/midpoint.test.ts
+++ b/packages/geo/src/__tests__/midpoint.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { calculateGeographicCenter, calculateMidpointWithMetrics } from "../midpoint";
+import {
+  calculateGeographicCenter,
+  calculateMidpointWithMetrics,
+  optimizeMeetingPoint,
+} from "../midpoint";
+import { distanceStandardDeviation, haversineDistance } from "../distance";
 import type { Coordinates } from "@meetpoint/types";
 
 describe("calculateGeographicCenter", () => {
@@ -52,5 +57,51 @@ describe("calculateMidpointWithMetrics", () => {
     expect(typeof result.maxDistanceKm).toBe("number");
     expect(result.averageDistanceKm).toBeGreaterThan(0);
     expect(result.maxDistanceKm).toBeGreaterThanOrEqual(result.averageDistanceKm);
+  });
+});
+
+describe("optimizeMeetingPoint", () => {
+  it("never increases dispersion relative to the geographic centre", () => {
+    const pts: Coordinates[] = [
+      { lat: 48.85, lng: 2.35 },
+      { lat: 48.86, lng: 2.36 },
+      { lat: 45.76, lng: 4.83 },
+    ];
+
+    const stdCenter = distanceStandardDeviation(calculateGeographicCenter(pts), pts);
+    const stdOptimized = distanceStandardDeviation(optimizeMeetingPoint(pts), pts);
+
+    expect(stdOptimized).toBeLessThanOrEqual(stdCenter);
+  });
+
+  it("reaches a fairer point far from the centroid (search radius scales with spread)", () => {
+    // Two nearby points + one far away: the fair point sits tens of km from the
+    // vector centroid, well beyond the old fixed 2 km search box.
+    const pts: Coordinates[] = [
+      { lat: 48.85, lng: 2.35 },
+      { lat: 48.87, lng: 2.4 },
+      { lat: 43.3, lng: 5.4 },
+    ];
+
+    const center = calculateGeographicCenter(pts);
+    const optimized = optimizeMeetingPoint(pts);
+
+    expect(distanceStandardDeviation(optimized, pts)).toBeLessThan(
+      distanceStandardDeviation(center, pts)
+    );
+    expect(haversineDistance(center, optimized)).toBeGreaterThan(5);
+  });
+
+  it("returns the centre for two already-equidistant points", () => {
+    const points: Coordinates[] = [
+      { lat: 49.0, lng: 2.35 },
+      { lat: 48.7, lng: 2.35 },
+    ];
+
+    const center = calculateGeographicCenter(points);
+    const optimized = optimizeMeetingPoint(points);
+
+    expect(optimized.lat).toBeCloseTo(center.lat, 5);
+    expect(optimized.lng).toBeCloseTo(center.lng, 5);
   });
 });

--- a/packages/geo/src/__tests__/openroute.test.ts
+++ b/packages/geo/src/__tests__/openroute.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { createORSClient } from "../openroute";
+import type { Coordinates } from "@meetpoint/types";
+
+interface MatrixRequestBody {
+  locations: number[][];
+  sources: number[];
+  destinations: number[];
+  metrics: string[];
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("createORSClient.getMatrix", () => {
+  it("indexes sources and destinations independently when their counts differ", async () => {
+    let capturedBody: MatrixRequestBody | undefined;
+
+    const fetchMock = vi.fn(async (_url: string, init: RequestInit) => {
+      capturedBody = JSON.parse(init.body as string) as MatrixRequestBody;
+      return {
+        ok: true,
+        json: async () => ({ durations: [[60, 120, 180]] }),
+      } as Response;
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = createORSClient({ apiKey: "test-key" });
+    const sources: Coordinates[] = [{ lat: 48.0, lng: 2.0 }];
+    const destinations: Coordinates[] = [
+      { lat: 45.0, lng: 4.0 },
+      { lat: 43.0, lng: 5.0 },
+      { lat: 50.0, lng: 3.0 },
+    ];
+
+    const result = await client.getMatrix(sources, destinations, "driving");
+
+    expect(capturedBody).toBeDefined();
+    expect(capturedBody?.locations).toHaveLength(4);
+    expect(capturedBody?.sources).toEqual([0]);
+    // 1 source + 3 destinations -> destination indices must be [1, 2, 3],
+    // not [1] (the bug that mapped over `sources` instead of `destinations`).
+    expect(capturedBody?.destinations).toEqual([1, 2, 3]);
+    expect(result).toEqual([[1, 2, 3]]);
+  });
+});

--- a/packages/geo/src/midpoint.ts
+++ b/packages/geo/src/midpoint.ts
@@ -82,31 +82,56 @@ export function calculateWeightedMidpoint(points: Coordinates[], weights: number
   };
 }
 
+const KM_PER_DEGREE_LAT = 111;
+
 export function optimizeMeetingPoint(
   participants: Coordinates[],
   gridSize: number = 5,
-  radiusKm: number = 2
+  radiusKm?: number
 ): Coordinates {
   const center = calculateGeographicCenter(participants);
 
-  const radiusDeg = radiusKm / 111;
+  if (participants.length < 2) {
+    return center;
+  }
+
+  // Scale the search area to how spread out the participants are: refining
+  // inside a fixed 2 km box is meaningless when people are tens of km apart.
+  const distancesToCenter = participants.map((p) => haversineDistance(center, p));
+  const avgDistanceKm = distancesToCenter.reduce((a, b) => a + b, 0) / distancesToCenter.length;
+  let searchRadiusKm = radiusKm ?? Math.max(2, avgDistanceKm * 0.5);
 
   let bestPoint = center;
   let bestStdDev = distanceStandardDeviation(center, participants);
 
-  for (let i = -gridSize; i <= gridSize; i++) {
-    for (let j = -gridSize; j <= gridSize; j++) {
-      const candidate: Coordinates = {
-        lat: center.lat + (i * radiusDeg) / gridSize,
-        lng: center.lng + (j * radiusDeg) / gridSize,
-      };
+  // Coarse-to-fine: scan a grid around the best point, then zoom in and repeat.
+  // This covers a wide area without losing resolution near the optimum.
+  const REFINEMENT_PASSES = 4;
+  for (let pass = 0; pass < REFINEMENT_PASSES; pass++) {
+    const origin = bestPoint;
+    const latRadiusDeg = searchRadiusKm / KM_PER_DEGREE_LAT;
+    // 1° of longitude shrinks with latitude, so the grid must not be square in
+    // degrees, otherwise it is anisotropic on the ground.
+    const cosLat = Math.cos(degreesToRadians(origin.lat));
+    const lngRadiusDeg = searchRadiusKm / (KM_PER_DEGREE_LAT * Math.max(Math.abs(cosLat), 1e-6));
 
-      const stdDev = distanceStandardDeviation(candidate, participants);
-      if (stdDev < bestStdDev) {
-        bestStdDev = stdDev;
-        bestPoint = candidate;
+    for (let i = -gridSize; i <= gridSize; i++) {
+      for (let j = -gridSize; j <= gridSize; j++) {
+        const candidate: Coordinates = {
+          lat: origin.lat + (i * latRadiusDeg) / gridSize,
+          lng: origin.lng + (j * lngRadiusDeg) / gridSize,
+        };
+
+        const stdDev = distanceStandardDeviation(candidate, participants);
+        if (stdDev < bestStdDev) {
+          bestStdDev = stdDev;
+          bestPoint = candidate;
+        }
       }
     }
+
+    // Zoom in: next pass searches within one step of the current best point.
+    searchRadiusKm /= gridSize;
   }
 
   return bestPoint;

--- a/packages/geo/src/openroute.ts
+++ b/packages/geo/src/openroute.ts
@@ -111,7 +111,7 @@ export function createORSClient(config: ORSConfig) {
       body: JSON.stringify({
         locations: allCoordinates,
         sources: sources.map((_, i) => i),
-        destinations: sources.map((_, i) => sources.length + i),
+        destinations: destinations.map((_, i) => sources.length + i),
         metrics: ["duration"],
       }),
     });


### PR DESCRIPTION
optimizeMeetingPoint used a fixed 2 km search box, which is meaningless when participants are tens or hundreds of km apart (the centroid was returned unchanged). It was also square in degrees, so the grid was anisotropic away from the equator.

- Size the search radius from the participants' average distance to the centroid, and refine coarse-to-fine (4 zooming passes) for precision over a wide area.
- Scale the longitude step by cos(lat) so the grid is isotropic on the ground.
- Fix getMatrix in the ORS client: destination indices were derived from `sources` instead of `destinations`, dropping/aliasing destinations whenever the two counts differed.
- Add tests: dispersion never worsens vs the centroid, a far cluster reaches a fair point well beyond 2 km, two-point input returns the centre, and getMatrix sends [1,2,3] for 1 source + 3 destinations.