### PR TITLE
ci: type-check convex and trigger CI on develop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 jobs:
   quality:
@@ -25,6 +25,8 @@ jobs:
         run: pnpm lint
       - name: Type check
         run: pnpm type-check
+      - name: Type check (convex)
+        run: pnpm --filter @meetpoint/web exec tsc -p ../../convex/tsconfig.json --noEmit
       - name: Build
         run: pnpm build
         env:

--- a/convex/tsconfig.json
+++ b/convex/tsconfig.json
@@ -11,7 +11,9 @@
     "isolatedModules": true,
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
-    "verbatimModuleSyntax": true
+    "verbatimModuleSyntax": true,
+    "types": ["node"],
+    "typeRoots": ["../apps/web/node_modules/@types", "../node_modules/@types"]
   },
   "include": ["./**/*.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## Summary
- convex is now type-checked in CI via `tsc -p convex/tsconfig.json`
- CI now runs on `develop` (push and pull_request)

## Changes
- convex/tsconfig.json: add node types and typeRoots so the convex type-check passes
- .github/workflows/ci.yml: extend triggers to develop, add convex type-check step

## Test plan
- [ ] CI runs on the PR and the convex type-check step passes