### PR TITLE
fix(backend): validate and bound convex input lengths and coords

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -19,6 +19,7 @@ import type * as places from "../places.js";
 import type * as routing from "../routing.js";
 import type * as routingInternal from "../routingInternal.js";
 import type * as searchPlaces from "../searchPlaces.js";
+import type * as validation from "../validation.js";
 import type * as votes from "../votes.js";
 
 import type {
@@ -39,6 +40,7 @@ declare const fullApi: ApiFromModules<{
   routing: typeof routing;
   routingInternal: typeof routingInternal;
   searchPlaces: typeof searchPlaces;
+  validation: typeof validation;
   votes: typeof votes;
 }>;
 

--- a/convex/ai.ts
+++ b/convex/ai.ts
@@ -1,6 +1,7 @@
 import { action, internalAction, mutation, query } from "./_generated/server";
 import { internal } from "./_generated/api";
 import { v } from "convex/values";
+import { AI_PREFERENCES_MAX, validateRequiredText } from "./validation";
 
 const ANTHROPIC_API_URL = "https://api.anthropic.com/v1/messages";
 const ANTHROPIC_MODEL = "claude-haiku-4-5";
@@ -275,9 +276,11 @@ export const suggestCities = action({
     ),
   },
   handler: async (ctx, args): Promise<SuggestCitiesResult> => {
+    const preferences = validateRequiredText(args.preferences, "Préférences", AI_PREFERENCES_MAX);
+
     return await ctx.runAction(internal.ai._suggestCities, {
       participantLocations: args.participantLocations,
-      preferences: args.preferences,
+      preferences,
     });
   },
 });

--- a/convex/meets.ts
+++ b/convex/meets.ts
@@ -1,5 +1,13 @@
 import { v } from "convex/values";
 import { mutation, query } from "./_generated/server";
+import {
+  CREATOR_NAME_MAX,
+  DESCRIPTION_MAX,
+  MEET_NAME_MAX,
+  validateCoordinates,
+  validateOptionalText,
+  validateRequiredText,
+} from "./validation";
 
 const MAX_SHARE_CODE_ATTEMPTS = 10;
 
@@ -39,6 +47,11 @@ export const create = mutation({
     scheduledFor: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
+    const name = validateRequiredText(args.name, "Nom du rendez-vous", MEET_NAME_MAX);
+    const description = validateOptionalText(args.description, "Description", DESCRIPTION_MAX);
+    const creatorName = validateRequiredText(args.creatorName, "Nom du créateur", CREATOR_NAME_MAX);
+    validateCoordinates(args.creatorLocation, "Localisation du créateur");
+
     const now = Date.now();
 
     let shareCode = generateShareCode();
@@ -55,9 +68,9 @@ export const create = mutation({
     }
 
     const meetId = await ctx.db.insert("meets", {
-      name: args.name,
-      description: args.description,
-      creatorName: args.creatorName,
+      name,
+      description,
+      creatorName,
       shareCode,
       filters: args.filters ?? {},
       status: "pending",
@@ -68,7 +81,7 @@ export const create = mutation({
 
     await ctx.db.insert("participants", {
       meetId,
-      name: args.creatorName,
+      name: creatorName,
       location: args.creatorLocation,
       address: args.creatorAddress,
       transportMode: args.transportMode,

--- a/convex/participants.ts
+++ b/convex/participants.ts
@@ -1,5 +1,6 @@
 import { v } from "convex/values";
 import { mutation, query } from "./_generated/server";
+import { PARTICIPANT_NAME_MAX, validateCoordinates, validateRequiredText } from "./validation";
 
 export const join = mutation({
   args: {
@@ -18,6 +19,9 @@ export const join = mutation({
     ),
   },
   handler: async (ctx, args) => {
+    const name = validateRequiredText(args.name, "Nom du participant", PARTICIPANT_NAME_MAX);
+    validateCoordinates(args.location, "Localisation du participant");
+
     const meet = await ctx.db.get(args.meetId);
     if (!meet) {
       throw new Error("Meeting not found");
@@ -30,7 +34,7 @@ export const join = mutation({
     const existingParticipant = await ctx.db
       .query("participants")
       .withIndex("by_meet", (q) => q.eq("meetId", args.meetId))
-      .filter((q) => q.eq(q.field("name"), args.name))
+      .filter((q) => q.eq(q.field("name"), name))
       .first();
 
     if (existingParticipant) {
@@ -41,7 +45,7 @@ export const join = mutation({
 
     const participantId = await ctx.db.insert("participants", {
       meetId: args.meetId,
-      name: args.name,
+      name,
       location: args.location,
       address: args.address,
       transportMode: args.transportMode,
@@ -67,6 +71,8 @@ export const updateLocation = mutation({
     address: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
+    validateCoordinates(args.location, "Localisation du participant");
+
     const participant = await ctx.db.get(args.participantId);
     if (!participant) {
       throw new Error("Participant not found");

--- a/convex/validation.ts
+++ b/convex/validation.ts
@@ -1,0 +1,53 @@
+export const MEET_NAME_MAX = 80;
+export const DESCRIPTION_MAX = 500;
+export const CREATOR_NAME_MAX = 60;
+export const PARTICIPANT_NAME_MAX = 60;
+export const AI_PREFERENCES_MAX = 500;
+
+const LATITUDE_MIN = -90;
+const LATITUDE_MAX = 90;
+const LONGITUDE_MIN = -180;
+const LONGITUDE_MAX = 180;
+
+type Coordinates = {
+  lat: number;
+  lng: number;
+};
+
+export function validateRequiredText(value: string, label: string, max: number): string {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    throw new Error(`Le champ « ${label} » est requis.`);
+  }
+  if (trimmed.length > max) {
+    throw new Error(`Le champ « ${label} » ne doit pas dépasser ${max} caractères.`);
+  }
+  return trimmed;
+}
+
+export function validateOptionalText(
+  value: string | undefined,
+  label: string,
+  max: number
+): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return undefined;
+  }
+  if (trimmed.length > max) {
+    throw new Error(`Le champ « ${label} » ne doit pas dépasser ${max} caractères.`);
+  }
+  return trimmed;
+}
+
+export function validateCoordinates(coords: Coordinates, label: string): void {
+  const { lat, lng } = coords;
+  const isLatValid = Number.isFinite(lat) && lat >= LATITUDE_MIN && lat <= LATITUDE_MAX;
+  const isLngValid = Number.isFinite(lng) && lng >= LONGITUDE_MIN && lng <= LONGITUDE_MAX;
+  if (!isLatValid || !isLngValid) {
+    throw new Error(`Coordonnées invalides pour « ${label} ».`);
+  }
+}


### PR DESCRIPTION
## Summary
- Add a defensive validation layer on public Convex mutations/actions (PR2)
- Purely additive, no behavior change for valid inputs

## Changes
- convex/validation.ts: new helpers bounding string lengths and validating coordinates
- convex/meets.ts: bound name/description/creatorName, validate finite WGS-84 coords
- convex/participants.ts: bound participant name, validate coords on join/updateLocation
- convex/ai.ts: bound AI preferences to 500 chars on suggestCities

## Test plan
- [ ] Create a meet with over-length name/description -> rejected (French error)
- [ ] Join with out-of-range or non-finite coords -> rejected
- [ ] suggestCities with preferences over 500 chars -> rejected
- [ ] Valid inputs still succeed unchanged