### PR TITLE
feat(frontend): add native share, qr code and join deep-link

### DIFF
--- a/apps/web/app/join/page.tsx
+++ b/apps/web/app/join/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { useRouter } from "next/navigation";
+import { Suspense, useState, useEffect } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { motion } from "framer-motion";
 import { Button, Input } from "@meetpoint/ui";
@@ -9,10 +9,25 @@ import { useQuery } from "convex/react";
 import { api } from "../../../../convex/_generated/api";
 import { PageBackground } from "@/components/page-background";
 
-export default function JoinPage() {
+function sanitizeCode(value: string) {
+  return value
+    .toUpperCase()
+    .replace(/[^A-Z0-9]/g, "")
+    .slice(0, 6);
+}
+
+function JoinForm() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const [code, setCode] = useState("");
   const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const initialCode = searchParams.get("code");
+    if (initialCode) {
+      setCode(sanitizeCode(initialCode));
+    }
+  }, [searchParams]);
 
   const meet = useQuery(
     api.meets.getByShareCode,
@@ -34,11 +49,7 @@ export default function JoinPage() {
   }, [code.length, meet]);
 
   const handleCodeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value
-      .toUpperCase()
-      .replace(/[^A-Z0-9]/g, "")
-      .slice(0, 6);
-    setCode(value);
+    setCode(sanitizeCode(e.target.value));
   };
 
   return (
@@ -143,5 +154,25 @@ export default function JoinPage() {
         </div>
       </div>
     </main>
+  );
+}
+
+function JoinFallback() {
+  return (
+    <main className="bg-keria-darker relative flex min-h-screen items-center justify-center overflow-hidden">
+      <PageBackground />
+      <div className="relative z-10 flex flex-col items-center gap-4">
+        <div className="border-keria-gold h-8 w-8 animate-spin rounded-full border-2 border-t-transparent" />
+        <span className="text-keria-muted text-sm">Chargement...</span>
+      </div>
+    </main>
+  );
+}
+
+export default function JoinPage() {
+  return (
+    <Suspense fallback={<JoinFallback />}>
+      <JoinForm />
+    </Suspense>
   );
 }

--- a/apps/web/app/meet/[id]/page.tsx
+++ b/apps/web/app/meet/[id]/page.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { useAction } from "convex/react";
 import { motion } from "framer-motion";
 import { Button, Badge } from "@meetpoint/ui";
+import { QRCodeSVG } from "qrcode.react";
 import dynamic from "next/dynamic";
 import { useMeet, useAiSuggestions } from "@/hooks";
 import { MapMarker, MapMidpoint, MapRoute } from "@/components/map";
@@ -130,14 +131,24 @@ export default function MeetPage({ params }: { params: Promise<{ id: string }> }
   const [isCalculatingRoutes, setIsCalculatingRoutes] = useState(false);
   const [routes, setRoutes] = useState<RouteData[]>([]);
   const [codeCopied, setCodeCopied] = useState(false);
+  const [linkCopied, setLinkCopied] = useState(false);
+  const [canShare, setCanShare] = useState(false);
   const [aiCities, setAiCities] = useState<SuggestedCity[]>([]);
   const [selectedCity, setSelectedCity] = useState<SelectedCity | null>(meet?.selectedCity ?? null);
 
-  const handleCopyCode = () => {
+  useEffect(() => {
+    setCanShare(typeof navigator !== "undefined" && typeof navigator.share === "function");
+  }, []);
+
+  const handleCopyCode = async () => {
     if (!shareCode) return;
-    navigator.clipboard.writeText(shareCode);
-    setCodeCopied(true);
-    setTimeout(() => setCodeCopied(false), 2000);
+    try {
+      await navigator.clipboard.writeText(shareCode);
+      setCodeCopied(true);
+      setTimeout(() => setCodeCopied(false), 2000);
+    } catch {
+      setCodeCopied(false);
+    }
   };
 
   useEffect(() => {
@@ -304,10 +315,42 @@ export default function MeetPage({ params }: { params: Promise<{ id: string }> }
     );
   }
 
-  const shareUrl = typeof window !== "undefined" ? `${window.location.origin}/join` : "";
+  const shareUrl =
+    typeof window !== "undefined" && shareCode
+      ? `${window.location.origin}/join?code=${shareCode}`
+      : "";
   const maxTravelTime = participants
     ? Math.max(...participants.map((p: Doc<"participants">) => p.travelTimeMinutes ?? 0))
     : 0;
+
+  const handleCopyLink = async () => {
+    if (!shareUrl) return;
+    try {
+      await navigator.clipboard.writeText(shareUrl);
+      setLinkCopied(true);
+      setTimeout(() => setLinkCopied(false), 2000);
+    } catch {
+      setLinkCopied(false);
+    }
+  };
+
+  const handleShare = async () => {
+    if (!shareUrl) return;
+    if (canShare) {
+      try {
+        await navigator.share({
+          title: meet.name,
+          text: `Rejoignez « ${meet.name} » sur Keria`,
+          url: shareUrl,
+        });
+      } catch (error) {
+        if (error instanceof Error && error.name === "AbortError") return;
+        await handleCopyLink();
+      }
+      return;
+    }
+    await handleCopyLink();
+  };
 
   return (
     <main className="bg-keria-darker relative flex h-screen flex-col lg:flex-row">
@@ -382,7 +425,23 @@ export default function MeetPage({ params }: { params: Promise<{ id: string }> }
               <p className="text-keria-gold mt-1 font-mono text-3xl font-bold tracking-[0.2em]">
                 {shareCode}
               </p>
-              <p className="text-keria-muted mt-2 text-[10px]">{shareUrl}</p>
+              <p className="text-keria-muted mt-2 break-all text-[10px]">{shareUrl}</p>
+
+              {shareUrl && (
+                <div className="mt-4 flex flex-col items-center gap-4">
+                  <div className="bg-keria-cream rounded p-3">
+                    <QRCodeSVG value={shareUrl} size={148} level="M" />
+                  </div>
+                  <Button
+                    variant="primary"
+                    size="sm"
+                    className="w-full text-[10px] uppercase tracking-wider"
+                    onClick={handleShare}
+                  >
+                    {linkCopied ? "Lien copié" : "Partager"}
+                  </Button>
+                </div>
+              )}
             </div>
           )}
         </div>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,6 +18,7 @@
     "geist": "^1.5.1",
     "mapbox-gl": "^3.9.2",
     "next": "^15.1.4",
+    "qrcode.react": "^4.2.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-map-gl": "^7.1.8"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       next:
         specifier: ^15.1.4
         version: 15.5.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      qrcode.react:
+        specifier: ^4.2.0
+        version: 4.2.0(react@19.2.4)
       react:
         specifier: ^19.0.0
         version: 19.2.4
@@ -2390,6 +2393,11 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  qrcode.react@4.2.0:
+    resolution: {integrity: sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -5135,6 +5143,10 @@ snapshots:
   protocol-buffers-schema@3.6.0: {}
 
   punycode@2.3.1: {}
+
+  qrcode.react@4.2.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
 
   queue-microtask@1.2.3: {}
 


### PR DESCRIPTION
## Summary
- add a native share button using navigator.share with a robust clipboard copy fallback
- add a scannable QR code and a `/join?code=CODE` deep-link that pre-fills the code

## Changes
- meet/[id]/page.tsx: share button, QR code, deep-link generation
- join/page.tsx: read code from query, refactored under Suspense
- package.json / pnpm-lock.yaml: add qrcode.react dependency

## Test plan
- [ ] share button triggers native share, falls back to clipboard copy
- [ ] QR code scans to the join deep-link
- [ ] visiting /join?code=CODE pre-fills the code field