### PR TITLE
feat(frontend): add seo routes, pwa manifest and social image

### DIFF
--- a/apps/web/app/icon.tsx
+++ b/apps/web/app/icon.tsx
@@ -1,0 +1,27 @@
+import { ImageResponse } from "next/og";
+
+export const size = { width: 512, height: 512 };
+export const contentType = "image/png";
+
+export default function Icon() {
+  return new ImageResponse(
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        background: "#1e221a",
+        borderRadius: 112,
+        color: "#c9a227",
+        fontSize: 340,
+        fontWeight: 700,
+        letterSpacing: -12,
+      }}
+    >
+      K
+    </div>,
+    { ...size }
+  );
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,10 +1,11 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { GeistSans } from "geist/font/sans";
 import { GeistMono } from "geist/font/mono";
 import { Space_Grotesk } from "next/font/google";
 import { Providers } from "@/components/providers";
 import { LoadingScreenProvider } from "@/components/loading-screen-provider";
 import { Navigation } from "@/components/navigation";
+import { siteUrl } from "@/lib/site";
 import "./globals.css";
 
 const spaceGrotesk = Space_Grotesk({
@@ -14,6 +15,7 @@ const spaceGrotesk = Space_Grotesk({
 });
 
 export const metadata: Metadata = {
+  metadataBase: new URL(siteUrl),
   title: "KERIA - Trouvez le point de rencontre parfait",
   description:
     "Trouvez le point de rencontre le plus équitable entre plusieurs personnes. Simple, intelligent et élégant.",
@@ -25,7 +27,14 @@ export const metadata: Metadata = {
     type: "website",
     locale: "fr_FR",
     siteName: "KERIA",
+    url: siteUrl,
   },
+};
+
+export const viewport: Viewport = {
+  themeColor: "#1e221a",
+  width: "device-width",
+  initialScale: 1,
 };
 
 export default function RootLayout({

--- a/apps/web/app/manifest.ts
+++ b/apps/web/app/manifest.ts
@@ -1,0 +1,23 @@
+import type { MetadataRoute } from "next";
+import { siteTagline } from "@/lib/site";
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: `KERIA — ${siteTagline}`,
+    short_name: "KERIA",
+    description:
+      "Trouvez le point de rencontre le plus équitable entre plusieurs personnes. Simple, intelligent et élégant.",
+    start_url: "/",
+    display: "standalone",
+    background_color: "#1e221a",
+    theme_color: "#1e221a",
+    icons: [
+      {
+        src: "/icon",
+        sizes: "512x512",
+        type: "image/png",
+        purpose: "any",
+      },
+    ],
+  };
+}

--- a/apps/web/app/opengraph-image.tsx
+++ b/apps/web/app/opengraph-image.tsx
@@ -1,0 +1,63 @@
+import { ImageResponse } from "next/og";
+
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+export const alt = "KERIA — Le point de rencontre le plus juste";
+
+export default function OpenGraphImage() {
+  return new ImageResponse(
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "center",
+        padding: "0 96px",
+        background: "#1e221a",
+        backgroundImage: "radial-gradient(1100px 560px at 78% -8%, #2a2f23 0%, transparent 60%)",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 18,
+          color: "#c9a227",
+          fontSize: 30,
+          fontWeight: 600,
+          letterSpacing: 8,
+        }}
+      >
+        <div style={{ width: 56, height: 4, background: "#c9a227" }} />
+        POINT DE RENCONTRE
+      </div>
+      <div
+        style={{
+          display: "flex",
+          marginTop: 28,
+          color: "#f5f5dc",
+          fontSize: 230,
+          fontWeight: 700,
+          letterSpacing: -10,
+          lineHeight: 1,
+        }}
+      >
+        KERIA
+      </div>
+      <div
+        style={{
+          display: "flex",
+          marginTop: 36,
+          color: "#f5f5dc",
+          fontSize: 46,
+          fontWeight: 500,
+        }}
+      >
+        Le point de rencontre le plus
+        <span style={{ color: "#c9a227", marginLeft: 14 }}>juste</span>
+      </div>
+    </div>,
+    { ...size }
+  );
+}

--- a/apps/web/app/robots.ts
+++ b/apps/web/app/robots.ts
@@ -1,0 +1,13 @@
+import type { MetadataRoute } from "next";
+import { siteUrl } from "@/lib/site";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: ["/", "/event/new"],
+      disallow: ["/meet/", "/event/"],
+    },
+    sitemap: `${siteUrl}/sitemap.xml`,
+  };
+}

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -1,0 +1,13 @@
+import type { MetadataRoute } from "next";
+import { PUBLIC_ROUTES, siteUrl } from "@/lib/site";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const lastModified = new Date();
+
+  return PUBLIC_ROUTES.map((path) => ({
+    url: `${siteUrl}${path}`,
+    lastModified,
+    changeFrequency: "monthly",
+    priority: path === "/" ? 1 : 0.7,
+  }));
+}

--- a/apps/web/lib/site.ts
+++ b/apps/web/lib/site.ts
@@ -1,0 +1,7 @@
+export const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://keria-web.vercel.app";
+
+export const siteName = "KERIA";
+
+export const siteTagline = "Le point de rencontre le plus juste";
+
+export const PUBLIC_ROUTES = ["/", "/new", "/join", "/join-event", "/event/new"] as const;


### PR DESCRIPTION
## Summary
- add SEO infrastructure, PWA manifest and social sharing assets for the web app
- expose crawlable routes while keeping private sessions out of indexing

## Changes
- app/robots.ts: allow public routes (incl. /event/new), disallow private sessions (/meet/, /event/[id])
- app/sitemap.ts: list public routes
- app/manifest.ts + app/icon.tsx: PWA manifest and favicon generated via next/og
- app/opengraph-image.tsx: Open Graph image generated via next/og
- app/layout.tsx + lib/site.ts: metadataBase, viewport (themeColor) and shared site config

## Test plan
- [ ] verify /robots.txt blocks /meet/ and /event/[id], allows /event/new
- [ ] verify /sitemap.xml lists public routes
- [ ] verify /manifest.webmanifest, /icon and /opengraph-image render