### PR TITLE
ci: resolve pnpm version conflict in setup action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - uses: actions/setup-node@v4
         with:
           node-version: 20


### PR DESCRIPTION
## Summary
- CI failed at `pnpm/action-setup@v4` because the pnpm version was specified in two places: `version: 9` in the action and `packageManager` in package.json
- Removing `version` from the action lets it read the pinned version from `packageManager` (pnpm@9.15.2)

## Changes
- .github/workflows/ci.yml: drop `with: version: 9` from the pnpm setup step

## Test plan
- [ ] CI pipeline runs past the pnpm setup step without the multiple-versions error