### PR TITLE
feat(backend): compute event participant itinerary and timing

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -10,6 +10,7 @@
 
 import type * as ai from "../ai.js";
 import type * as eventParticipants from "../eventParticipants.js";
+import type * as eventRouting from "../eventRouting.js";
 import type * as eventStages from "../eventStages.js";
 import type * as events from "../events.js";
 import type * as googlePlaces from "../googlePlaces.js";
@@ -31,6 +32,7 @@ import type {
 declare const fullApi: ApiFromModules<{
   ai: typeof ai;
   eventParticipants: typeof eventParticipants;
+  eventRouting: typeof eventRouting;
   eventStages: typeof eventStages;
   events: typeof events;
   googlePlaces: typeof googlePlaces;

--- a/convex/eventParticipants.ts
+++ b/convex/eventParticipants.ts
@@ -1,5 +1,43 @@
 import { v } from "convex/values";
 import { mutation, query } from "./_generated/server";
+import { validateCoordinates } from "./validation";
+
+export const setLogistics = mutation({
+  args: {
+    participantId: v.id("eventParticipants"),
+    location: v.object({
+      lat: v.number(),
+      lng: v.number(),
+    }),
+    address: v.optional(v.string()),
+    transportMode: v.union(
+      v.literal("driving"),
+      v.literal("walking"),
+      v.literal("cycling"),
+      v.literal("transit")
+    ),
+  },
+  handler: async (ctx, args) => {
+    const participant = await ctx.db.get(args.participantId);
+    if (!participant) {
+      throw new Error("Participant non trouvé");
+    }
+
+    validateCoordinates(args.location, "Localisation du participant");
+
+    const now = Date.now();
+
+    await ctx.db.patch(args.participantId, {
+      location: args.location,
+      address: args.address,
+      transportMode: args.transportMode,
+    });
+
+    await ctx.db.patch(participant.eventId, {
+      updatedAt: now,
+    });
+  },
+});
 
 export const join = mutation({
   args: {

--- a/convex/eventRouting.ts
+++ b/convex/eventRouting.ts
@@ -1,0 +1,230 @@
+import { v } from "convex/values";
+import { action, internalMutation, internalQuery, query } from "./_generated/server";
+import { internal } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
+
+const DEPARTURE_SAFETY_MARGIN_MS = 5 * 60 * 1000;
+
+type Coordinates = {
+  lat: number;
+  lng: number;
+};
+
+type ItinerarySegment = {
+  fromStageId?: Id<"eventStages">;
+  toStageId: Id<"eventStages">;
+  durationMinutes: number;
+  distanceKm: number;
+  polyline: Coordinates[];
+  error?: string;
+};
+
+type ItineraryResult =
+  | { success: false; error: string }
+  | {
+      success: true;
+      totalDurationMinutes: number;
+      totalDistanceKm: number;
+      recommendedDepartureAt: number;
+      segments: ItinerarySegment[];
+    };
+
+const segmentValidator = v.object({
+  fromStageId: v.optional(v.id("eventStages")),
+  toStageId: v.id("eventStages"),
+  durationMinutes: v.number(),
+  distanceKm: v.number(),
+  polyline: v.array(
+    v.object({
+      lat: v.number(),
+      lng: v.number(),
+    })
+  ),
+});
+
+export const _getParticipant = internalQuery({
+  args: { eventParticipantId: v.id("eventParticipants") },
+  handler: async (ctx, args) => {
+    return await ctx.db.get(args.eventParticipantId);
+  },
+});
+
+export const _getStages = internalQuery({
+  args: { eventId: v.id("events") },
+  handler: async (ctx, args) => {
+    const stages = await ctx.db
+      .query("eventStages")
+      .withIndex("by_event_order", (q) => q.eq("eventId", args.eventId))
+      .collect();
+
+    return stages.sort((a, b) => a.order - b.order);
+  },
+});
+
+export const _saveItinerary = internalMutation({
+  args: {
+    eventId: v.id("events"),
+    eventParticipantId: v.id("eventParticipants"),
+    totalDurationMinutes: v.number(),
+    totalDistanceKm: v.number(),
+    recommendedDepartureAt: v.number(),
+    segments: v.array(segmentValidator),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+
+    const existing = await ctx.db
+      .query("eventItineraries")
+      .withIndex("by_participant", (q) => q.eq("eventParticipantId", args.eventParticipantId))
+      .first();
+
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        totalDurationMinutes: args.totalDurationMinutes,
+        totalDistanceKm: args.totalDistanceKm,
+        recommendedDepartureAt: args.recommendedDepartureAt,
+        segments: args.segments,
+        computedAt: now,
+      });
+      return existing._id;
+    }
+
+    return await ctx.db.insert("eventItineraries", {
+      eventId: args.eventId,
+      eventParticipantId: args.eventParticipantId,
+      totalDurationMinutes: args.totalDurationMinutes,
+      totalDistanceKm: args.totalDistanceKm,
+      recommendedDepartureAt: args.recommendedDepartureAt,
+      segments: args.segments,
+      computedAt: now,
+    });
+  },
+});
+
+export const calculateParticipantItinerary = action({
+  args: {
+    eventId: v.id("events"),
+    eventParticipantId: v.id("eventParticipants"),
+  },
+  handler: async (ctx, args): Promise<ItineraryResult> => {
+    const participant = await ctx.runQuery(internal.eventRouting._getParticipant, {
+      eventParticipantId: args.eventParticipantId,
+    });
+
+    if (!participant) {
+      return { success: false as const, error: "Participant non trouvé" };
+    }
+
+    if (!participant.location || !participant.transportMode) {
+      return { success: false as const, error: "Logistique du participant manquante" };
+    }
+
+    const stages = await ctx.runQuery(internal.eventRouting._getStages, {
+      eventId: args.eventId,
+    });
+
+    const [firstStage, ...remainingStages] = stages;
+    if (!firstStage) {
+      return { success: false as const, error: "Aucune étape pour cet événement" };
+    }
+
+    const transportMode = participant.transportMode;
+
+    const legs: Array<{
+      fromStageId?: Id<"eventStages">;
+      toStageId: Id<"eventStages">;
+      origin: Coordinates;
+      destination: Coordinates;
+    }> = [
+      {
+        toStageId: firstStage._id,
+        origin: participant.location,
+        destination: firstStage.location,
+      },
+    ];
+
+    let previousStage = firstStage;
+    for (const stage of remainingStages) {
+      legs.push({
+        fromStageId: previousStage._id,
+        toStageId: stage._id,
+        origin: previousStage.location,
+        destination: stage.location,
+      });
+      previousStage = stage;
+    }
+
+    const segments: ItinerarySegment[] = [];
+    let totalDurationMinutes = 0;
+    let totalDistanceKm = 0;
+
+    for (const leg of legs) {
+      const route = await ctx.runAction(internal.routingInternal.calculateRoute, {
+        originLat: leg.origin.lat,
+        originLng: leg.origin.lng,
+        destLat: leg.destination.lat,
+        destLng: leg.destination.lng,
+        transportMode,
+      });
+
+      if (route.success && route.durationMinutes !== null && route.distanceKm !== null) {
+        totalDurationMinutes += route.durationMinutes;
+        totalDistanceKm += route.distanceKm;
+        segments.push({
+          fromStageId: leg.fromStageId,
+          toStageId: leg.toStageId,
+          durationMinutes: route.durationMinutes,
+          distanceKm: route.distanceKm,
+          polyline: route.polyline,
+        });
+      } else {
+        segments.push({
+          fromStageId: leg.fromStageId,
+          toStageId: leg.toStageId,
+          durationMinutes: 0,
+          distanceKm: 0,
+          polyline: [],
+          error: route.error,
+        });
+      }
+    }
+
+    const firstSegment = segments[0];
+    const firstSegmentDurationMinutes = firstSegment ? firstSegment.durationMinutes : 0;
+    const recommendedDepartureAt =
+      firstStage.scheduledAt - firstSegmentDurationMinutes * 60 * 1000 - DEPARTURE_SAFETY_MARGIN_MS;
+
+    await ctx.runMutation(internal.eventRouting._saveItinerary, {
+      eventId: args.eventId,
+      eventParticipantId: args.eventParticipantId,
+      totalDurationMinutes,
+      totalDistanceKm,
+      recommendedDepartureAt,
+      segments: segments.map((segment) => ({
+        fromStageId: segment.fromStageId,
+        toStageId: segment.toStageId,
+        durationMinutes: segment.durationMinutes,
+        distanceKm: segment.distanceKm,
+        polyline: segment.polyline,
+      })),
+    });
+
+    return {
+      success: true as const,
+      totalDurationMinutes,
+      totalDistanceKm,
+      recommendedDepartureAt,
+      segments,
+    };
+  },
+});
+
+export const getItinerary = query({
+  args: { eventParticipantId: v.id("eventParticipants") },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("eventItineraries")
+      .withIndex("by_participant", (q) => q.eq("eventParticipantId", args.eventParticipantId))
+      .first();
+  },
+});


### PR DESCRIPTION
## Summary
- Add per-participant routing and timing for Event mode
- Compute when each participant should leave to reach the meeting point on time

## Changes
- eventParticipants: add setLogistics to store a participant position and transport mode
- eventRouting (new): sequential itinerary (participant to stops) reusing the ORS integration, with recommended departure time and an eventItineraries cache; returns a partial itinerary if a segment fails
- api.d.ts: register the new eventRouting module

## Test plan
- [ ] Set logistics for a participant (position + transport)
- [ ] Request itinerary and verify recommended departure time
- [ ] Verify cached result is reused on a second request
- [ ] Force a failing segment and confirm a partial itinerary is returned