### PR TITLE
feat(backend): add stage place suggestions and voting

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -10,8 +10,10 @@
 
 import type * as ai from "../ai.js";
 import type * as eventParticipants from "../eventParticipants.js";
+import type * as eventPlaces from "../eventPlaces.js";
 import type * as eventRouting from "../eventRouting.js";
 import type * as eventStages from "../eventStages.js";
+import type * as eventVotes from "../eventVotes.js";
 import type * as events from "../events.js";
 import type * as googlePlaces from "../googlePlaces.js";
 import type * as meets from "../meets.js";
@@ -32,8 +34,10 @@ import type {
 declare const fullApi: ApiFromModules<{
   ai: typeof ai;
   eventParticipants: typeof eventParticipants;
+  eventPlaces: typeof eventPlaces;
   eventRouting: typeof eventRouting;
   eventStages: typeof eventStages;
+  eventVotes: typeof eventVotes;
   events: typeof events;
   googlePlaces: typeof googlePlaces;
   meets: typeof meets;

--- a/convex/eventPlaces.ts
+++ b/convex/eventPlaces.ts
@@ -1,0 +1,144 @@
+import { v } from "convex/values";
+import { action, internalMutation, mutation, query } from "./_generated/server";
+import { internal } from "./_generated/api";
+import type { OverpassPlace } from "./searchPlaces";
+
+interface StageSearchResult {
+  success: boolean;
+  count: number;
+  error?: string;
+}
+
+export const addForStage = internalMutation({
+  args: {
+    eventStageId: v.id("eventStages"),
+    externalId: v.string(),
+    name: v.string(),
+    address: v.string(),
+    location: v.object({
+      lat: v.number(),
+      lng: v.number(),
+    }),
+    category: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query("places")
+      .withIndex("by_stage", (q) => q.eq("eventStageId", args.eventStageId))
+      .filter((q) => q.eq(q.field("externalId"), args.externalId))
+      .first();
+
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        name: args.name,
+        address: args.address,
+        location: args.location,
+        lastRefreshedAt: Date.now(),
+      });
+      return existing._id;
+    }
+
+    const now = Date.now();
+    return await ctx.db.insert("places", {
+      eventStageId: args.eventStageId,
+      externalId: args.externalId,
+      name: args.name,
+      address: args.address,
+      location: args.location,
+      category: args.category,
+      createdAt: now,
+      lastRefreshedAt: now,
+    });
+  },
+});
+
+export const listByStage = query({
+  args: { eventStageId: v.id("eventStages") },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("places")
+      .withIndex("by_stage", (q) => q.eq("eventStageId", args.eventStageId))
+      .collect();
+  },
+});
+
+export const searchForStage = action({
+  args: {
+    eventStageId: v.id("eventStages"),
+    radiusMeters: v.optional(v.number()),
+    categories: v.optional(v.array(v.string())),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args): Promise<StageSearchResult> => {
+    const stage = await ctx.runQuery(internal.eventStages.getInternal, {
+      stageId: args.eventStageId,
+    });
+
+    if (!stage) {
+      return {
+        success: false,
+        count: 0,
+        error: "Étape non trouvée",
+      };
+    }
+
+    try {
+      const places: OverpassPlace[] = await ctx.runAction(
+        internal.searchPlaces._fetchOverpassPlaces,
+        {
+          lat: stage.location.lat,
+          lng: stage.location.lng,
+          radiusMeters: args.radiusMeters,
+          categories: args.categories,
+          limit: args.limit,
+        }
+      );
+
+      for (const place of places) {
+        await ctx.runMutation(internal.eventPlaces.addForStage, {
+          eventStageId: args.eventStageId,
+          externalId: place.externalId,
+          name: place.name,
+          address: place.address,
+          location: place.location,
+          category: place.category,
+        });
+      }
+
+      return {
+        success: true,
+        count: places.length,
+      };
+    } catch (error) {
+      console.error("Error searching stage places:", error);
+      return {
+        success: false,
+        count: 0,
+        error: error instanceof Error ? error.message : "Unknown error",
+      };
+    }
+  },
+});
+
+export const clearByStage = mutation({
+  args: { eventStageId: v.id("eventStages") },
+  handler: async (ctx, args) => {
+    const places = await ctx.db
+      .query("places")
+      .withIndex("by_stage", (q) => q.eq("eventStageId", args.eventStageId))
+      .collect();
+
+    for (const place of places) {
+      const votes = await ctx.db
+        .query("votes")
+        .withIndex("by_place", (q) => q.eq("placeId", place._id))
+        .collect();
+
+      for (const vote of votes) {
+        await ctx.db.delete(vote._id);
+      }
+
+      await ctx.db.delete(place._id);
+    }
+  },
+});

--- a/convex/eventStages.ts
+++ b/convex/eventStages.ts
@@ -1,5 +1,5 @@
 import { v } from "convex/values";
-import { mutation, query } from "./_generated/server";
+import { internalQuery, mutation, query } from "./_generated/server";
 import { requireEventEditToken } from "./events";
 
 function getStageType(
@@ -206,6 +206,13 @@ export const remove = mutation({
 });
 
 export const get = query({
+  args: { stageId: v.id("eventStages") },
+  handler: async (ctx, args) => {
+    return await ctx.db.get(args.stageId);
+  },
+});
+
+export const getInternal = internalQuery({
   args: { stageId: v.id("eventStages") },
   handler: async (ctx, args) => {
     return await ctx.db.get(args.stageId);

--- a/convex/eventVotes.ts
+++ b/convex/eventVotes.ts
@@ -1,0 +1,127 @@
+import { v } from "convex/values";
+import { mutation, query } from "./_generated/server";
+
+export const cast = mutation({
+  args: {
+    eventStageId: v.id("eventStages"),
+    placeId: v.id("places"),
+    eventParticipantId: v.id("eventParticipants"),
+    vote: v.union(v.literal("up"), v.literal("down")),
+  },
+  handler: async (ctx, args) => {
+    const participant = await ctx.db.get(args.eventParticipantId);
+    if (!participant) {
+      throw new Error("Participant non trouvé");
+    }
+
+    const place = await ctx.db.get(args.placeId);
+    if (!place || place.eventStageId !== args.eventStageId) {
+      throw new Error("Lieu invalide pour cette étape");
+    }
+
+    const existingVote = await ctx.db
+      .query("votes")
+      .withIndex("by_stage_participant", (q) =>
+        q.eq("eventStageId", args.eventStageId).eq("eventParticipantId", args.eventParticipantId)
+      )
+      .filter((q) => q.eq(q.field("placeId"), args.placeId))
+      .first();
+
+    if (existingVote) {
+      await ctx.db.patch(existingVote._id, {
+        vote: args.vote,
+        votedAt: Date.now(),
+      });
+      return existingVote._id;
+    }
+
+    return await ctx.db.insert("votes", {
+      eventStageId: args.eventStageId,
+      placeId: args.placeId,
+      eventParticipantId: args.eventParticipantId,
+      vote: args.vote,
+      votedAt: Date.now(),
+    });
+  },
+});
+
+export const remove = mutation({
+  args: {
+    eventStageId: v.id("eventStages"),
+    placeId: v.id("places"),
+    eventParticipantId: v.id("eventParticipants"),
+  },
+  handler: async (ctx, args) => {
+    const vote = await ctx.db
+      .query("votes")
+      .withIndex("by_stage_participant", (q) =>
+        q.eq("eventStageId", args.eventStageId).eq("eventParticipantId", args.eventParticipantId)
+      )
+      .filter((q) => q.eq(q.field("placeId"), args.placeId))
+      .first();
+
+    if (vote) {
+      await ctx.db.delete(vote._id);
+    }
+  },
+});
+
+export const listByStage = query({
+  args: { eventStageId: v.id("eventStages") },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("votes")
+      .withIndex("by_stage", (q) => q.eq("eventStageId", args.eventStageId))
+      .collect();
+  },
+});
+
+export const getStageScore = query({
+  args: { placeId: v.id("places") },
+  handler: async (ctx, args) => {
+    const votes = await ctx.db
+      .query("votes")
+      .withIndex("by_place", (q) => q.eq("placeId", args.placeId))
+      .collect();
+
+    const upvotes = votes.filter((vote) => vote.vote === "up").length;
+    const downvotes = votes.filter((vote) => vote.vote === "down").length;
+
+    return {
+      upvotes,
+      downvotes,
+      score: upvotes - downvotes,
+      total: votes.length,
+    };
+  },
+});
+
+export const getStageRanking = query({
+  args: { eventStageId: v.id("eventStages") },
+  handler: async (ctx, args) => {
+    const places = await ctx.db
+      .query("places")
+      .withIndex("by_stage", (q) => q.eq("eventStageId", args.eventStageId))
+      .collect();
+
+    const votes = await ctx.db
+      .query("votes")
+      .withIndex("by_stage", (q) => q.eq("eventStageId", args.eventStageId))
+      .collect();
+
+    const placeScores = places.map((place) => {
+      const placeVotes = votes.filter((vote) => vote.placeId === place._id);
+      const upvotes = placeVotes.filter((vote) => vote.vote === "up").length;
+      const downvotes = placeVotes.filter((vote) => vote.vote === "down").length;
+
+      return {
+        place,
+        upvotes,
+        downvotes,
+        score: upvotes - downvotes,
+      };
+    });
+
+    return placeScores.sort((a, b) => b.score - a.score);
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -144,7 +144,7 @@ export default defineSchema({
     meetId: v.optional(v.id("meets")),
     eventStageId: v.optional(v.id("eventStages")),
     placeId: v.id("places"),
-    participantId: v.id("participants"),
+    participantId: v.optional(v.id("participants")),
     eventParticipantId: v.optional(v.id("eventParticipants")),
 
     vote: v.union(v.literal("up"), v.literal("down")),

--- a/convex/searchPlaces.ts
+++ b/convex/searchPlaces.ts
@@ -13,6 +13,15 @@ const PLACE_CATEGORIES = {
 
 type PlaceCategory = keyof typeof PLACE_CATEGORIES;
 
+export type OverpassPlace = {
+  externalId: string;
+  name: string;
+  address: string;
+  location: { lat: number; lng: number };
+  category: string;
+  cuisine?: string;
+};
+
 // Explicit return type breaks the self-referential inference (TS7022/7023) caused
 // by these actions calling back into api.*/internal.*. `places` is consumed via
 // the reactive query on the client, so its element shape is left opaque here.
@@ -43,16 +52,15 @@ interface OverpassElement {
   };
 }
 
-export const _searchNearby = internalAction({
+export const _fetchOverpassPlaces = internalAction({
   args: {
-    meetId: v.id("meets"),
     lat: v.number(),
     lng: v.number(),
     radiusMeters: v.optional(v.number()),
     categories: v.optional(v.array(v.string())),
     limit: v.optional(v.number()),
   },
-  handler: async (ctx, args): Promise<OverpassSearchResult> => {
+  handler: async (_ctx, args): Promise<OverpassPlace[]> => {
     const radius = args.radiusMeters ?? 1000;
     const limit = args.limit ?? 15;
     const categories = (args.categories ?? ["restaurant", "cafe", "bar"]) as PlaceCategory[];
@@ -75,51 +83,74 @@ export const _searchNearby = internalAction({
       out center ${limit};
     `;
 
-    try {
-      const response = await fetch("https://overpass-api.de/api/interpreter", {
-        method: "POST",
-        body: `data=${encodeURIComponent(overpassQuery)}`,
-        headers: {
-          "Content-Type": "application/x-www-form-urlencoded",
-        },
+    const response = await fetch("https://overpass-api.de/api/interpreter", {
+      method: "POST",
+      body: `data=${encodeURIComponent(overpassQuery)}`,
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Overpass API error: ${response.status}`);
+    }
+
+    const data = await response.json();
+    const elements: OverpassElement[] = data.elements || [];
+
+    return elements
+      .filter((el) => el.tags?.name)
+      .map((el) => {
+        const lat = el.lat ?? el.center?.lat ?? 0;
+        const lon = el.lon ?? el.center?.lon ?? 0;
+
+        let category = "other";
+        if (el.tags?.amenity === "restaurant") category = "restaurant";
+        else if (el.tags?.amenity === "cafe") category = "cafe";
+        else if (el.tags?.amenity === "bar" || el.tags?.amenity === "pub") category = "bar";
+        else if (el.tags?.amenity === "fast_food") category = "fast_food";
+        else if (el.tags?.amenity === "cinema") category = "cinema";
+        else if (el.tags?.leisure === "park") category = "park";
+
+        const addressParts = [];
+        if (el.tags?.["addr:housenumber"]) addressParts.push(el.tags["addr:housenumber"]);
+        if (el.tags?.["addr:street"]) addressParts.push(el.tags["addr:street"]);
+        if (el.tags?.["addr:city"]) addressParts.push(el.tags["addr:city"]);
+        const address = addressParts.join(" ") || "Adresse non disponible";
+
+        return {
+          externalId: `osm-${el.type}-${el.id}`,
+          name: el.tags?.name || "Sans nom",
+          address,
+          location: { lat, lng: lon },
+          category,
+          cuisine: el.tags?.cuisine,
+        };
       });
+  },
+});
 
-      if (!response.ok) {
-        throw new Error(`Overpass API error: ${response.status}`);
-      }
-
-      const data = await response.json();
-      const elements: OverpassElement[] = data.elements || [];
-
-      const places = elements
-        .filter((el) => el.tags?.name)
-        .map((el) => {
-          const lat = el.lat ?? el.center?.lat ?? 0;
-          const lon = el.lon ?? el.center?.lon ?? 0;
-
-          let category = "other";
-          if (el.tags?.amenity === "restaurant") category = "restaurant";
-          else if (el.tags?.amenity === "cafe") category = "cafe";
-          else if (el.tags?.amenity === "bar" || el.tags?.amenity === "pub") category = "bar";
-          else if (el.tags?.amenity === "fast_food") category = "fast_food";
-          else if (el.tags?.amenity === "cinema") category = "cinema";
-          else if (el.tags?.leisure === "park") category = "park";
-
-          const addressParts = [];
-          if (el.tags?.["addr:housenumber"]) addressParts.push(el.tags["addr:housenumber"]);
-          if (el.tags?.["addr:street"]) addressParts.push(el.tags["addr:street"]);
-          if (el.tags?.["addr:city"]) addressParts.push(el.tags["addr:city"]);
-          const address = addressParts.join(" ") || "Adresse non disponible";
-
-          return {
-            externalId: `osm-${el.type}-${el.id}`,
-            name: el.tags?.name || "Sans nom",
-            address,
-            location: { lat, lng: lon },
-            category,
-            cuisine: el.tags?.cuisine,
-          };
-        });
+export const _searchNearby = internalAction({
+  args: {
+    meetId: v.id("meets"),
+    lat: v.number(),
+    lng: v.number(),
+    radiusMeters: v.optional(v.number()),
+    categories: v.optional(v.array(v.string())),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args): Promise<OverpassSearchResult> => {
+    try {
+      const places: OverpassPlace[] = await ctx.runAction(
+        internal.searchPlaces._fetchOverpassPlaces,
+        {
+          lat: args.lat,
+          lng: args.lng,
+          radiusMeters: args.radiusMeters,
+          categories: args.categories,
+          limit: args.limit,
+        }
+      );
 
       for (const place of places) {
         await ctx.runMutation(api.places.add, {


### PR DESCRIPTION
## Summary
- Overpass search extracted into a generic reusable action shared by meet and event flows (zero regression on meet)
- New per-stage place suggestions and voting for the Event mode

## Changes
- convex/searchPlaces.ts: extract _fetchOverpassPlaces, reused by meet and event
- convex/eventPlaces.ts: stage-scoped place search and persistence
- convex/eventVotes.ts: up/down voting and per-stage ranking via eventParticipantId
- convex/eventStages.ts, convex/schema.ts, convex/_generated/api.d.ts: supporting wiring and schema

## Test plan
- [ ] Suggest places for an event stage and persist them
- [ ] Vote up/down on a stage and check the ranking
- [ ] Confirm meet place search still works unchanged