### PR TITLE
feat(frontend): event editing, lifecycle, qr share and join prefill

### DIFF
--- a/apps/web/app/event/[id]/page.tsx
+++ b/apps/web/app/event/[id]/page.tsx
@@ -6,10 +6,24 @@ import Link from "next/link";
 import { motion } from "framer-motion";
 import { Badge } from "@meetpoint/ui";
 import dynamic from "next/dynamic";
-import { useEvent, useEventParticipants } from "@/hooks";
+import { useEvent, useEventStages, useEventParticipants } from "@/hooks";
 import { MapStageMarker, MapStagePath } from "@/components/map";
-import { StagesList, RSVPButtons, ParticipantsRSVPList } from "@/components/event";
+import {
+  StagesList,
+  RSVPButtons,
+  ParticipantsRSVPList,
+  EventShareCard,
+  EventEditForm,
+  EventLifecycleControls,
+  EventStagesEditor,
+} from "@/components/event";
 import { PageBackground } from "@/components/page-background";
+import {
+  resolveDisplayStatus,
+  getStatusLabel,
+  getStatusBadgeVariant,
+  type EventStatus,
+} from "@/lib/event-status";
 import type { MapContainerHandle } from "@/components/map";
 import type { Id, Doc } from "../../../../../convex/_generated/dataModel";
 import type { RsvpStatus } from "@meetpoint/types";
@@ -27,7 +41,17 @@ export default function EventPage({ params }: { params: Promise<{ id: string }> 
   const shareCode = searchParams.get("code");
 
   const eventId = id as Id<"events">;
-  const { event, stages, participants, rsvpCounts, isLoading } = useEvent(eventId);
+  const {
+    event,
+    stages,
+    participants,
+    rsvpCounts,
+    isLoading,
+    isEditor,
+    updateEvent,
+    updateStatus,
+  } = useEvent(eventId);
+  const { addStage, updateStage, removeStage } = useEventStages(eventId);
   const { rsvp } = useEventParticipants(eventId);
 
   const mapRef = useRef<MapContainerHandle>(null);
@@ -35,15 +59,21 @@ export default function EventPage({ params }: { params: Promise<{ id: string }> 
     null
   );
   const [selectedStage, setSelectedStage] = useState<Doc<"eventStages"> | null>(null);
-  const [codeCopied, setCodeCopied] = useState(false);
 
   useEffect(() => {
-    const stored = localStorage.getItem(`meetpoint-event-participant-${eventId}`);
-    if (stored && participants) {
-      const participant = participants.find((p: Doc<"eventParticipants">) => p._id === stored);
-      if (participant) {
-        setCurrentParticipantId(participant._id);
-      }
+    if (!participants) return;
+    const storageKey = `meetpoint-event-participant-${eventId}`;
+    const stored = localStorage.getItem(storageKey);
+    if (!stored) {
+      setCurrentParticipantId(null);
+      return;
+    }
+    const participant = participants.find((p: Doc<"eventParticipants">) => p._id === stored);
+    if (participant) {
+      setCurrentParticipantId(participant._id);
+    } else {
+      localStorage.removeItem(storageKey);
+      setCurrentParticipantId(null);
     }
   }, [eventId, participants]);
 
@@ -101,17 +131,15 @@ export default function EventPage({ params }: { params: Promise<{ id: string }> 
     );
   }
 
-  const shareUrl = typeof window !== "undefined" ? `${window.location.origin}/join-event` : "";
   const currentParticipant = participants?.find(
     (p: Doc<"eventParticipants">) => p._id === currentParticipantId
   );
 
-  const handleCopyCode = () => {
-    if (!shareCode) return;
-    navigator.clipboard.writeText(shareCode);
-    setCodeCopied(true);
-    setTimeout(() => setCodeCopied(false), 2000);
-  };
+  const displayStatus = resolveDisplayStatus({
+    status: event.status as EventStatus,
+    startsAt: event.startsAt,
+    endsAt: event.endsAt,
+  });
 
   const formatDate = (timestamp: number) => {
     return new Date(timestamp).toLocaleDateString("fr-FR", {
@@ -129,20 +157,12 @@ export default function EventPage({ params }: { params: Promise<{ id: string }> 
     });
   };
 
-  const statusLabels: Record<string, string> = {
-    published: "Publié",
-    ongoing: "En cours",
-    completed: "Terminé",
-    cancelled: "Annulé",
-    draft: "Brouillon",
-  };
-
   return (
     <main className="bg-keria-darker relative flex h-screen flex-col lg:flex-row">
       <PageBackground />
 
       {/* Sidebar */}
-      <aside className="border-keria-forest/20 bg-keria-darker relative z-10 max-h-[50vh] w-full overflow-y-auto border-b p-5 lg:max-h-none lg:w-[380px] lg:overflow-visible lg:border-b-0 lg:border-r">
+      <aside className="border-keria-forest/20 bg-keria-darker relative z-10 max-h-[50vh] w-full overflow-y-auto border-b p-5 lg:h-screen lg:max-h-none lg:w-[380px] lg:overflow-y-auto lg:border-b-0 lg:border-r">
         {/* Header */}
         <div className="mb-6 flex items-center justify-between">
           <Link
@@ -151,24 +171,13 @@ export default function EventPage({ params }: { params: Promise<{ id: string }> 
           >
             KERIA
           </Link>
-          <Badge
-            variant={
-              event.status === "published"
-                ? "success"
-                : event.status === "ongoing"
-                  ? "warning"
-                  : event.status === "completed"
-                    ? "primary"
-                    : "danger"
-            }
-            className="text-[10px] uppercase"
-          >
-            {statusLabels[event.status]}
+          <Badge variant={getStatusBadgeVariant(displayStatus)} className="text-[10px] uppercase">
+            {getStatusLabel(displayStatus)}
           </Badge>
         </div>
 
         {/* Event info */}
-        <div className="mb-6">
+        <section className="mb-6">
           <h1 className="border-keria-gold font-display text-keria-cream border-l-2 pl-3 text-2xl font-bold">
             {event.name}
           </h1>
@@ -184,62 +193,46 @@ export default function EventPage({ params }: { params: Promise<{ id: string }> 
             </p>
           </div>
 
-          {shareCode && (
-            <div className="border-keria-gold/30 bg-keria-gold/5 mt-4 rounded border p-4">
-              <div className="flex items-center justify-between">
-                <p className="text-keria-gold text-[10px] uppercase tracking-wider">
-                  Code de partage
-                </p>
-                <button
-                  onClick={handleCopyCode}
-                  className="text-keria-gold hover:bg-keria-gold/10 hover:text-keria-gold flex items-center gap-1 rounded px-2 py-1 text-[10px] uppercase tracking-wider transition-colors"
-                >
-                  {codeCopied ? (
-                    <>
-                      <svg
-                        width="12"
-                        height="12"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="2"
-                      >
-                        <polyline points="20 6 9 17 4 12" />
-                      </svg>
-                      Copié
-                    </>
-                  ) : (
-                    <>
-                      <svg
-                        width="12"
-                        height="12"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="2"
-                      >
-                        <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
-                        <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" />
-                      </svg>
-                      Copier
-                    </>
-                  )}
-                </button>
-              </div>
-              <p className="text-keria-gold mt-1 font-mono text-3xl font-bold tracking-[0.2em]">
-                {shareCode}
-              </p>
-              <p className="text-keria-muted mt-2 text-[10px]">{shareUrl}</p>
-            </div>
+          {isEditor && (
+            <EventEditForm name={event.name} description={event.description} onSave={updateEvent} />
           )}
-        </div>
+        </section>
+
+        {/* Lifecycle controls (creator only) */}
+        {isEditor && (
+          <section className="border-keria-forest/30 bg-keria-forest/10 mb-6 rounded border p-4">
+            <h2 className="text-keria-muted mb-3 text-xs font-medium uppercase tracking-wider">
+              Cycle de vie
+            </h2>
+            <EventLifecycleControls
+              status={event.status as EventStatus}
+              onChangeStatus={updateStatus}
+            />
+          </section>
+        )}
+
+        {/* Share card */}
+        {shareCode && (
+          <section className="mb-6">
+            <EventShareCard eventName={event.name} shareCode={shareCode} />
+          </section>
+        )}
 
         {/* Stages */}
-        <div className="mb-6">
+        <section className="mb-6">
           <h2 className="border-keria-gold text-keria-muted mb-3 border-l-2 pl-3 text-xs font-medium uppercase tracking-wider">
             Étapes ({stages?.length ?? 0})
           </h2>
-          {stages && stages.length > 0 ? (
+          {isEditor ? (
+            <EventStagesEditor
+              stages={stages ?? []}
+              onAddStage={addStage}
+              onUpdateStage={updateStage}
+              onRemoveStage={removeStage}
+              onStageClick={handleStageClick}
+              selectedStageId={selectedStage?._id}
+            />
+          ) : stages && stages.length > 0 ? (
             <StagesList
               stages={stages}
               onStageClick={handleStageClick}
@@ -248,11 +241,11 @@ export default function EventPage({ params }: { params: Promise<{ id: string }> 
           ) : (
             <p className="text-keria-muted text-sm">Aucune étape</p>
           )}
-        </div>
+        </section>
 
         {/* Current participant RSVP */}
         {currentParticipant && (
-          <div className="border-keria-forest/30 bg-keria-forest/10 mb-6 rounded border p-4">
+          <section className="border-keria-forest/30 bg-keria-forest/10 mb-6 rounded border p-4">
             <h2 className="text-keria-muted mb-2 text-xs font-medium uppercase tracking-wider">
               Votre réponse
             </h2>
@@ -264,12 +257,12 @@ export default function EventPage({ params }: { params: Promise<{ id: string }> 
               currentStatus={currentParticipant.rsvpStatus as RsvpStatus}
               onRSVP={handleRSVP}
             />
-          </div>
+          </section>
         )}
 
         {/* Join prompt */}
         {!currentParticipantId && participants && participants.length > 0 && (
-          <div className="border-keria-gold/30 bg-keria-gold/5 mb-6 rounded border p-4">
+          <section className="border-keria-gold/30 bg-keria-gold/5 mb-6 rounded border p-4">
             <p className="text-keria-muted text-sm">Vous n'êtes pas encore inscrit.</p>
             <a
               href={`/event/${eventId}/join${shareCode ? `?code=${shareCode}` : ""}`}
@@ -277,11 +270,11 @@ export default function EventPage({ params }: { params: Promise<{ id: string }> 
             >
               Rejoindre l'événement
             </a>
-          </div>
+          </section>
         )}
 
         {/* Participants */}
-        <div>
+        <section>
           <h2 className="border-keria-gold text-keria-muted mb-3 border-l-2 pl-3 text-xs font-medium uppercase tracking-wider">
             Participants ({participants?.length ?? 0})
           </h2>
@@ -294,7 +287,7 @@ export default function EventPage({ params }: { params: Promise<{ id: string }> 
           ) : (
             <p className="text-keria-muted text-sm">Aucun participant</p>
           )}
-        </div>
+        </section>
       </aside>
 
       {/* Map */}

--- a/apps/web/app/event/new/page.tsx
+++ b/apps/web/app/event/new/page.tsx
@@ -109,6 +109,7 @@ export default function NewEventPage() {
       });
 
       localStorage.setItem(`meetpoint-event-participant-${result.eventId}`, result.participantId);
+      localStorage.setItem(`meetpoint-event-edit-token-${result.eventId}`, result.editToken);
       router.push(`/event/${result.eventId}?code=${result.shareCode}`);
     } catch {
       setError("Erreur lors de la création de l'événement");

--- a/apps/web/app/join-event/page.tsx
+++ b/apps/web/app/join-event/page.tsx
@@ -1,17 +1,32 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { useRouter } from "next/navigation";
+import { Suspense, useState, useEffect } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { motion } from "framer-motion";
 import { Button, Input } from "@meetpoint/ui";
 import { useEventByShareCode } from "@/hooks";
 import { PageBackground } from "@/components/page-background";
 
-export default function JoinEventPage() {
+function sanitizeCode(value: string) {
+  return value
+    .toUpperCase()
+    .replace(/[^A-Z0-9]/g, "")
+    .slice(0, 6);
+}
+
+function JoinEventForm() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const [code, setCode] = useState("");
   const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const initialCode = searchParams.get("code");
+    if (initialCode) {
+      setCode(sanitizeCode(initialCode));
+    }
+  }, [searchParams]);
 
   const { event, isLoading } = useEventByShareCode(code.length === 6 ? code : undefined);
 
@@ -30,8 +45,7 @@ export default function JoinEventPage() {
   }, [code.length, isLoading, event]);
 
   const handleCodeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value.toUpperCase().slice(0, 6);
-    setCode(value);
+    setCode(sanitizeCode(e.target.value));
   };
 
   return (
@@ -136,5 +150,25 @@ export default function JoinEventPage() {
         </div>
       </div>
     </main>
+  );
+}
+
+function JoinEventFallback() {
+  return (
+    <main className="bg-keria-darker relative flex min-h-screen items-center justify-center overflow-hidden">
+      <PageBackground />
+      <div className="relative z-10 flex flex-col items-center gap-4">
+        <div className="border-keria-gold h-8 w-8 animate-spin rounded-full border-2 border-t-transparent" />
+        <span className="text-keria-muted text-sm">Chargement...</span>
+      </div>
+    </main>
+  );
+}
+
+export default function JoinEventPage() {
+  return (
+    <Suspense fallback={<JoinEventFallback />}>
+      <JoinEventForm />
+    </Suspense>
   );
 }

--- a/apps/web/components/event/event-edit-form.tsx
+++ b/apps/web/components/event/event-edit-form.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { Button, Input } from "@meetpoint/ui";
+
+interface EventEditFormProps {
+  name: string;
+  description?: string;
+  onSave: (values: { name: string; description?: string }) => Promise<unknown>;
+}
+
+export function EventEditForm({ name, description, onSave }: EventEditFormProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [draftName, setDraftName] = useState(name);
+  const [draftDescription, setDraftDescription] = useState(description ?? "");
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleOpen = () => {
+    setDraftName(name);
+    setDraftDescription(description ?? "");
+    setError(null);
+    setIsOpen(true);
+  };
+
+  const handleSave = async () => {
+    setError(null);
+    if (!draftName.trim()) {
+      setError("Le nom est obligatoire");
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      await onSave({
+        name: draftName.trim(),
+        description: draftDescription.trim() || undefined,
+      });
+      setIsOpen(false);
+    } catch {
+      setError("Erreur lors de l'enregistrement");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div className="mt-4">
+      {isOpen ? null : (
+        <motion.button
+          onClick={handleOpen}
+          className="border-keria-forest/50 text-keria-muted hover:border-keria-gold/50 hover:text-keria-gold flex w-full items-center justify-center gap-2 rounded border border-dashed bg-transparent py-2 text-[10px] font-medium uppercase tracking-wider transition-colors"
+          whileHover={{ scale: 1.01 }}
+          whileTap={{ scale: 0.98 }}
+        >
+          <svg
+            width="12"
+            height="12"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            aria-hidden="true"
+          >
+            <path d="M12 20h9" />
+            <path d="M16.5 3.5a2.12 2.12 0 013 3L7 19l-4 1 1-4z" />
+          </svg>
+          Modifier l'événement
+        </motion.button>
+      )}
+
+      <AnimatePresence>
+        {isOpen && (
+          <motion.div
+            initial={{ opacity: 0, height: 0 }}
+            animate={{ opacity: 1, height: "auto" }}
+            exit={{ opacity: 0, height: 0 }}
+            transition={{ duration: 0.25, ease: "easeInOut" }}
+            className="overflow-hidden"
+          >
+            <div className="border-keria-gold/30 bg-keria-gold/5 space-y-4 rounded border p-4">
+              <div>
+                <label
+                  htmlFor="event-edit-name"
+                  className="text-keria-muted mb-1 block text-[10px] font-medium uppercase tracking-wider"
+                >
+                  Nom de l'événement
+                </label>
+                <Input
+                  id="event-edit-name"
+                  value={draftName}
+                  onChange={(e) => setDraftName(e.target.value)}
+                  className="border-keria-forest/30 bg-keria-darker/50 backdrop-blur-sm"
+                />
+              </div>
+
+              <div>
+                <label
+                  htmlFor="event-edit-description"
+                  className="text-keria-muted mb-1 block text-[10px] font-medium uppercase tracking-wider"
+                >
+                  Description
+                </label>
+                <Input
+                  id="event-edit-description"
+                  value={draftDescription}
+                  onChange={(e) => setDraftDescription(e.target.value)}
+                  placeholder="Décrivez votre événement..."
+                  className="border-keria-forest/30 bg-keria-darker/50 backdrop-blur-sm"
+                />
+              </div>
+
+              {error && (
+                <div className="border-keria-error/30 bg-keria-error/10 text-keria-error-light rounded border p-2 text-xs">
+                  {error}
+                </div>
+              )}
+
+              <div className="flex gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="flex-1 text-[10px] uppercase tracking-wider"
+                  onClick={() => setIsOpen(false)}
+                >
+                  Annuler
+                </Button>
+                <Button
+                  variant="primary"
+                  size="sm"
+                  className="flex-1 text-[10px] uppercase tracking-wider"
+                  onClick={handleSave}
+                  isLoading={isSaving}
+                >
+                  Enregistrer
+                </Button>
+              </div>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/apps/web/components/event/event-lifecycle-controls.tsx
+++ b/apps/web/components/event/event-lifecycle-controls.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useState } from "react";
+import { motion } from "framer-motion";
+import { Button } from "@meetpoint/ui";
+import type { EventStatus } from "@/lib/event-status";
+
+interface LifecycleTransition {
+  target: EventStatus;
+  label: string;
+  variant: "primary" | "outline" | "destructive";
+}
+
+interface EventLifecycleControlsProps {
+  status: EventStatus;
+  onChangeStatus: (status: EventStatus) => Promise<unknown>;
+}
+
+const TRANSITIONS_BY_STATUS: Record<EventStatus, LifecycleTransition[]> = {
+  draft: [{ target: "published", label: "Publier", variant: "primary" }],
+  published: [
+    { target: "completed", label: "Clôturer", variant: "outline" },
+    { target: "cancelled", label: "Annuler", variant: "destructive" },
+  ],
+  ongoing: [
+    { target: "completed", label: "Clôturer", variant: "outline" },
+    { target: "cancelled", label: "Annuler", variant: "destructive" },
+  ],
+  completed: [],
+  cancelled: [{ target: "published", label: "Republier", variant: "primary" }],
+};
+
+export function EventLifecycleControls({ status, onChangeStatus }: EventLifecycleControlsProps) {
+  const [pendingTarget, setPendingTarget] = useState<EventStatus | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const transitions = TRANSITIONS_BY_STATUS[status];
+
+  if (transitions.length === 0) return null;
+
+  const handleTransition = async (target: EventStatus) => {
+    setError(null);
+    setPendingTarget(target);
+    try {
+      await onChangeStatus(target);
+    } catch {
+      setError("Erreur lors du changement de statut");
+    } finally {
+      setPendingTarget(null);
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap gap-2">
+        {transitions.map((transition) => (
+          <motion.div
+            key={transition.target}
+            className="flex-1"
+            whileHover={{ scale: 1.02 }}
+            whileTap={{ scale: 0.98 }}
+          >
+            <Button
+              variant={transition.variant}
+              size="sm"
+              className="w-full text-[10px] uppercase tracking-wider"
+              onClick={() => handleTransition(transition.target)}
+              isLoading={pendingTarget === transition.target}
+            >
+              {transition.label}
+            </Button>
+          </motion.div>
+        ))}
+      </div>
+
+      {error && (
+        <div className="border-keria-error/30 bg-keria-error/10 text-keria-error-light rounded border p-2 text-xs">
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/event/event-share-card.tsx
+++ b/apps/web/components/event/event-share-card.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Button } from "@meetpoint/ui";
+import { QRCodeSVG } from "qrcode.react";
+
+interface EventShareCardProps {
+  eventName: string;
+  shareCode: string;
+}
+
+export function EventShareCard({ eventName, shareCode }: EventShareCardProps) {
+  const [codeCopied, setCodeCopied] = useState(false);
+  const [linkCopied, setLinkCopied] = useState(false);
+  const [canShare, setCanShare] = useState(false);
+
+  useEffect(() => {
+    setCanShare(typeof navigator !== "undefined" && typeof navigator.share === "function");
+  }, []);
+
+  const shareUrl =
+    typeof window !== "undefined" ? `${window.location.origin}/join-event?code=${shareCode}` : "";
+
+  const handleCopyCode = async () => {
+    try {
+      await navigator.clipboard.writeText(shareCode);
+      setCodeCopied(true);
+      setTimeout(() => setCodeCopied(false), 2000);
+    } catch {
+      setCodeCopied(false);
+    }
+  };
+
+  const handleCopyLink = async () => {
+    if (!shareUrl) return;
+    try {
+      await navigator.clipboard.writeText(shareUrl);
+      setLinkCopied(true);
+      setTimeout(() => setLinkCopied(false), 2000);
+    } catch {
+      setLinkCopied(false);
+    }
+  };
+
+  const handleShare = async () => {
+    if (!shareUrl) return;
+    if (canShare) {
+      try {
+        await navigator.share({
+          title: eventName,
+          text: `Rejoignez « ${eventName} » sur Keria`,
+          url: shareUrl,
+        });
+      } catch (error) {
+        if (error instanceof Error && error.name === "AbortError") return;
+        await handleCopyLink();
+      }
+      return;
+    }
+    await handleCopyLink();
+  };
+
+  return (
+    <div className="border-keria-gold/30 bg-keria-gold/5 rounded border p-4">
+      <div className="flex items-center justify-between">
+        <p className="text-keria-gold text-[10px] uppercase tracking-wider">Code de partage</p>
+        <button
+          onClick={handleCopyCode}
+          className="text-keria-gold hover:bg-keria-gold/10 hover:text-keria-gold flex items-center gap-1 rounded px-2 py-1 text-[10px] uppercase tracking-wider transition-colors"
+        >
+          {codeCopied ? (
+            <>
+              <svg
+                width="12"
+                height="12"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                aria-hidden="true"
+              >
+                <polyline points="20 6 9 17 4 12" />
+              </svg>
+              Copié
+            </>
+          ) : (
+            <>
+              <svg
+                width="12"
+                height="12"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                aria-hidden="true"
+              >
+                <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+                <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" />
+              </svg>
+              Copier
+            </>
+          )}
+        </button>
+      </div>
+      <p className="text-keria-gold mt-1 font-mono text-3xl font-bold tracking-[0.2em]">
+        {shareCode}
+      </p>
+      {shareUrl && <p className="text-keria-muted mt-2 break-all text-[10px]">{shareUrl}</p>}
+
+      {shareUrl && (
+        <div className="mt-4 flex flex-col items-center gap-4">
+          <div className="bg-keria-cream rounded p-3">
+            <QRCodeSVG value={shareUrl} size={148} level="M" />
+          </div>
+          <Button
+            variant="primary"
+            size="sm"
+            className="w-full text-[10px] uppercase tracking-wider"
+            onClick={handleShare}
+          >
+            {linkCopied ? "Lien copié" : "Partager"}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/event/event-stages-editor.tsx
+++ b/apps/web/components/event/event-stages-editor.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { StageForm, type StageFormData } from "./stage-form";
+import { StagesList } from "./stages-list";
+import type { Coordinates } from "@meetpoint/types";
+import type { Doc, Id } from "../../../../convex/_generated/dataModel";
+
+interface AddStageInput {
+  name: string;
+  description?: string;
+  location: Coordinates;
+  address: string;
+  scheduledAt: number;
+  estimatedDurationMinutes?: number;
+}
+
+interface UpdateStageInput extends AddStageInput {
+  stageId: Id<"eventStages">;
+}
+
+interface EventStagesEditorProps {
+  stages: Doc<"eventStages">[];
+  onAddStage: (input: AddStageInput) => Promise<unknown>;
+  onUpdateStage: (input: UpdateStageInput) => Promise<unknown>;
+  onRemoveStage: (stageId: Id<"eventStages">) => Promise<unknown>;
+  onStageClick?: (stage: Doc<"eventStages">) => void;
+  selectedStageId?: string;
+}
+
+type EditorMode =
+  | { type: "closed" }
+  | { type: "add" }
+  | { type: "edit"; stage: Doc<"eventStages"> };
+
+export function EventStagesEditor({
+  stages,
+  onAddStage,
+  onUpdateStage,
+  onRemoveStage,
+  onStageClick,
+  selectedStageId,
+}: EventStagesEditorProps) {
+  const [mode, setMode] = useState<EditorMode>({ type: "closed" });
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const closeModal = () => {
+    setMode({ type: "closed" });
+    setError(null);
+  };
+
+  const handleSubmit = async (data: StageFormData) => {
+    setError(null);
+    setIsSubmitting(true);
+    try {
+      if (mode.type === "add") {
+        await onAddStage(data);
+      } else if (mode.type === "edit") {
+        await onUpdateStage({ stageId: mode.stage._id, ...data });
+      }
+      closeModal();
+    } catch {
+      setError("Erreur lors de l'enregistrement de l'étape");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleRemove = async (stageId: string) => {
+    if (stages.length <= 2) return;
+    setError(null);
+    try {
+      await onRemoveStage(stageId as Id<"eventStages">);
+    } catch {
+      setError("Impossible de supprimer cette étape");
+    }
+  };
+
+  const editInitialData =
+    mode.type === "edit"
+      ? {
+          name: mode.stage.name,
+          description: mode.stage.description,
+          location: mode.stage.location,
+          address: mode.stage.address,
+          scheduledAt: mode.stage.scheduledAt,
+          estimatedDurationMinutes: mode.stage.estimatedDurationMinutes,
+        }
+      : undefined;
+
+  return (
+    <div className="space-y-3">
+      {stages.length > 0 ? (
+        <StagesList
+          stages={stages}
+          onStageClick={(stage) => {
+            onStageClick?.(stage);
+            setMode({ type: "edit", stage });
+          }}
+          selectedStageId={selectedStageId}
+          showActions
+          onRemoveStage={handleRemove}
+        />
+      ) : (
+        <p className="text-keria-muted text-sm">Aucune étape</p>
+      )}
+
+      {error && (
+        <div className="border-keria-error/30 bg-keria-error/10 text-keria-error-light rounded border p-2 text-xs">
+          {error}
+        </div>
+      )}
+
+      <motion.button
+        onClick={() => setMode({ type: "add" })}
+        className="border-keria-forest/50 text-keria-muted hover:border-keria-gold/50 hover:text-keria-gold flex w-full items-center justify-center gap-2 rounded border border-dashed bg-transparent p-3 text-xs uppercase tracking-wider transition-colors"
+        whileHover={{ scale: 1.01 }}
+        whileTap={{ scale: 0.98 }}
+      >
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          aria-hidden="true"
+        >
+          <path d="M12 5v14M5 12h14" />
+        </svg>
+        Ajouter une étape
+      </motion.button>
+
+      <AnimatePresence>
+        {mode.type !== "closed" && (
+          <motion.div
+            className="bg-keria-darker/80 fixed inset-0 z-50 flex items-center justify-center p-4 backdrop-blur-sm"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            onClick={closeModal}
+          >
+            <motion.div
+              className="border-keria-forest/30 bg-keria-darker w-full max-w-lg overflow-y-auto rounded-xl border p-6 shadow-2xl"
+              style={{ maxHeight: "90vh" }}
+              initial={{ opacity: 0, scale: 0.95, y: 20 }}
+              animate={{ opacity: 1, scale: 1, y: 0 }}
+              exit={{ opacity: 0, scale: 0.95, y: 20 }}
+              transition={{ duration: 0.25, ease: "easeOut" }}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className="mb-5 flex items-center justify-between">
+                <h3 className="font-display text-keria-cream text-lg font-bold">
+                  {mode.type === "add" ? "Nouvelle étape" : "Modifier l'étape"}
+                </h3>
+                <button
+                  onClick={closeModal}
+                  aria-label="Fermer"
+                  className="text-keria-muted hover:bg-keria-forest/30 hover:text-keria-cream rounded p-1.5 transition-colors"
+                >
+                  <svg
+                    width="18"
+                    height="18"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    aria-hidden="true"
+                  >
+                    <path d="M18 6L6 18M6 6l12 12" />
+                  </svg>
+                </button>
+              </div>
+
+              <StageForm
+                initialData={editInitialData}
+                onSubmit={handleSubmit}
+                onCancel={closeModal}
+                submitLabel={mode.type === "add" ? "Ajouter" : "Enregistrer"}
+                isLoading={isSubmitting}
+              />
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/apps/web/components/event/index.ts
+++ b/apps/web/components/event/index.ts
@@ -2,3 +2,7 @@ export * from "./stage-form";
 export * from "./stages-list";
 export * from "./rsvp-buttons";
 export * from "./participants-rsvp-list";
+export * from "./event-share-card";
+export * from "./event-edit-form";
+export * from "./event-lifecycle-controls";
+export * from "./event-stages-editor";

--- a/apps/web/hooks/use-event.ts
+++ b/apps/web/hooks/use-event.ts
@@ -1,8 +1,49 @@
 "use client";
 
+import { useCallback, useEffect, useState } from "react";
 import { useQuery, useMutation } from "convex/react";
 import { api } from "../../../convex/_generated/api";
+import type { Coordinates } from "@meetpoint/types";
+import type { EventStatus } from "@/lib/event-status";
 import type { Id } from "../../../convex/_generated/dataModel";
+
+interface UpdateEventArgs {
+  name?: string;
+  description?: string;
+}
+
+interface AddStageArgs {
+  name: string;
+  description?: string;
+  location: Coordinates;
+  address: string;
+  scheduledAt: number;
+  estimatedDurationMinutes?: number;
+}
+
+interface UpdateStageArgs {
+  stageId: Id<"eventStages">;
+  name?: string;
+  description?: string;
+  location?: Coordinates;
+  address?: string;
+  scheduledAt?: number;
+  estimatedDurationMinutes?: number;
+}
+
+function useEditToken(eventId: Id<"events"> | undefined): string | null {
+  const [editToken, setEditToken] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!eventId) {
+      setEditToken(null);
+      return;
+    }
+    setEditToken(localStorage.getItem(`meetpoint-event-edit-token-${eventId}`));
+  }, [eventId]);
+
+  return editToken;
+}
 
 export function useEvent(eventId: Id<"events"> | undefined) {
   const event = useQuery(api.events.get, eventId ? { id: eventId } : "skip");
@@ -10,9 +51,37 @@ export function useEvent(eventId: Id<"events"> | undefined) {
   const participants = useQuery(api.events.getParticipants, eventId ? { eventId } : "skip");
   const rsvpCounts = useQuery(api.events.countByRsvp, eventId ? { eventId } : "skip");
 
-  const updateEvent = useMutation(api.events.update);
-  const updateStatus = useMutation(api.events.updateStatus);
-  const removeEvent = useMutation(api.events.remove);
+  const editToken = useEditToken(eventId);
+
+  const isEditor = useQuery(
+    api.events.verifyEditToken,
+    eventId && editToken ? { eventId, editToken } : "skip"
+  );
+
+  const updateEventMutation = useMutation(api.events.update);
+  const updateStatusMutation = useMutation(api.events.updateStatus);
+  const removeEventMutation = useMutation(api.events.remove);
+
+  const updateEvent = useCallback(
+    (args: UpdateEventArgs) => {
+      if (!eventId || !editToken) throw new Error("Action non autorisée");
+      return updateEventMutation({ eventId, editToken, ...args });
+    },
+    [eventId, editToken, updateEventMutation]
+  );
+
+  const updateStatus = useCallback(
+    (status: EventStatus) => {
+      if (!eventId || !editToken) throw new Error("Action non autorisée");
+      return updateStatusMutation({ eventId, editToken, status });
+    },
+    [eventId, editToken, updateStatusMutation]
+  );
+
+  const removeEvent = useCallback(() => {
+    if (!eventId || !editToken) throw new Error("Action non autorisée");
+    return removeEventMutation({ eventId, editToken });
+  }, [eventId, editToken, removeEventMutation]);
 
   return {
     event,
@@ -20,6 +89,7 @@ export function useEvent(eventId: Id<"events"> | undefined) {
     participants,
     rsvpCounts,
     isLoading: event === undefined,
+    isEditor: isEditor === true,
     updateEvent,
     updateStatus,
     removeEvent,
@@ -44,9 +114,35 @@ export function useCreateEvent() {
 export function useEventStages(eventId: Id<"events"> | undefined) {
   const stages = useQuery(api.eventStages.listByEvent, eventId ? { eventId } : "skip");
 
-  const addStage = useMutation(api.eventStages.add);
-  const updateStage = useMutation(api.eventStages.update);
-  const removeStage = useMutation(api.eventStages.remove);
+  const editToken = useEditToken(eventId);
+
+  const addStageMutation = useMutation(api.eventStages.add);
+  const updateStageMutation = useMutation(api.eventStages.update);
+  const removeStageMutation = useMutation(api.eventStages.remove);
+
+  const addStage = useCallback(
+    (args: AddStageArgs) => {
+      if (!eventId || !editToken) throw new Error("Action non autorisée");
+      return addStageMutation({ eventId, editToken, ...args });
+    },
+    [eventId, editToken, addStageMutation]
+  );
+
+  const updateStage = useCallback(
+    ({ stageId, ...args }: UpdateStageArgs) => {
+      if (!editToken) throw new Error("Action non autorisée");
+      return updateStageMutation({ stageId, editToken, ...args });
+    },
+    [editToken, updateStageMutation]
+  );
+
+  const removeStage = useCallback(
+    (stageId: Id<"eventStages">) => {
+      if (!editToken) throw new Error("Action non autorisée");
+      return removeStageMutation({ stageId, editToken });
+    },
+    [editToken, removeStageMutation]
+  );
 
   return {
     stages,

--- a/apps/web/lib/event-status.ts
+++ b/apps/web/lib/event-status.ts
@@ -1,0 +1,45 @@
+export type EventStatus = "draft" | "published" | "ongoing" | "completed" | "cancelled";
+
+export type BadgeVariant = "default" | "primary" | "success" | "warning" | "danger";
+
+const STATUS_LABELS: Record<EventStatus, string> = {
+  draft: "Brouillon",
+  published: "Publié",
+  ongoing: "En cours",
+  completed: "Terminé",
+  cancelled: "Annulé",
+};
+
+const STATUS_BADGE_VARIANTS: Record<EventStatus, BadgeVariant> = {
+  draft: "default",
+  published: "success",
+  ongoing: "warning",
+  completed: "primary",
+  cancelled: "danger",
+};
+
+interface DisplayStatusInput {
+  status: EventStatus;
+  startsAt: number;
+  endsAt?: number;
+  now?: number;
+}
+
+export function resolveDisplayStatus({
+  status,
+  startsAt,
+  endsAt,
+  now = Date.now(),
+}: DisplayStatusInput): EventStatus {
+  if (status !== "published") return status;
+  if (endsAt !== undefined && now >= startsAt && now <= endsAt) return "ongoing";
+  return status;
+}
+
+export function getStatusLabel(status: EventStatus): string {
+  return STATUS_LABELS[status];
+}
+
+export function getStatusBadgeVariant(status: EventStatus): BadgeVariant {
+  return STATUS_BADGE_VARIANTS[status];
+}


### PR DESCRIPTION
## Summary
- Add event editing UI and full lifecycle management on the web app
- Provide QR code sharing and prefill the join flow from a code link

## Changes
- event/[id]: edit event and stages (gated by editToken), lifecycle controls (draft -> published -> closed/cancelled)
- event-share-card: QR code and native share
- join-event: prefill code from /join-event?code=
- use-event: fix stale localStorage participant

## Test plan
- [ ] Edit an event and its stages with a valid editToken
- [ ] Move an event through draft -> published -> closed/cancelled
- [ ] Scan the QR code and use native share
- [ ] Open /join-event?code=XXXX and confirm the code is prefilled