### PR TITLE
feat(frontend): show participant itinerary and departure timing

### DIFF
--- a/apps/web/app/event/[id]/page.tsx
+++ b/apps/web/app/event/[id]/page.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import { use, useState, useEffect, useRef } from "react";
+import { use, useState, useEffect, useRef, useMemo } from "react";
 import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { motion } from "framer-motion";
 import { Badge } from "@meetpoint/ui";
 import dynamic from "next/dynamic";
-import { useEvent, useEventStages, useEventParticipants } from "@/hooks";
-import { MapStageMarker, MapStagePath } from "@/components/map";
+import { useEvent, useEventStages, useEventParticipants, useEventItinerary } from "@/hooks";
+import { MapStageMarker, MapStagePath, MapRoute } from "@/components/map";
 import {
   StagesList,
   RSVPButtons,
@@ -16,6 +16,8 @@ import {
   EventEditForm,
   EventLifecycleControls,
   EventStagesEditor,
+  ParticipantLogisticsForm,
+  ItineraryTimeline,
 } from "@/components/event";
 import { PageBackground } from "@/components/page-background";
 import {
@@ -26,7 +28,7 @@ import {
 } from "@/lib/event-status";
 import type { MapContainerHandle } from "@/components/map";
 import type { Id, Doc } from "../../../../../convex/_generated/dataModel";
-import type { RsvpStatus } from "@meetpoint/types";
+import type { RsvpStatus, TransportMode } from "@meetpoint/types";
 
 const MapContainer = dynamic(
   () => import("@/components/map/map-container").then((m) => ({ default: m.MapContainer })),
@@ -34,6 +36,8 @@ const MapContainer = dynamic(
 );
 
 type StageType = "departure" | "intermediate" | "arrival";
+
+const PARTICIPANT_ROUTE_COLOR = "#c9a227";
 
 export default function EventPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params);
@@ -57,6 +61,10 @@ export default function EventPage({ params }: { params: Promise<{ id: string }> 
   const mapRef = useRef<MapContainerHandle>(null);
   const [currentParticipantId, setCurrentParticipantId] = useState<Id<"eventParticipants"> | null>(
     null
+  );
+  const { itinerary, isCalculating, setLogistics, calculate } = useEventItinerary(
+    eventId,
+    currentParticipantId
   );
   const [selectedStage, setSelectedStage] = useState<Doc<"eventStages"> | null>(null);
 
@@ -105,6 +113,27 @@ export default function EventPage({ params }: { params: Promise<{ id: string }> 
     mapRef.current?.fitBounds(locations, 80);
   };
 
+  const currentParticipant = participants?.find(
+    (p: Doc<"eventParticipants">) => p._id === currentParticipantId
+  );
+
+  const hasLogistics = Boolean(currentParticipant?.location && currentParticipant?.transportMode);
+
+  const itineraryRoutes = useMemo(() => {
+    if (!itinerary || !currentParticipant) return [];
+    const drawableSegments = itinerary.segments.filter((segment) => segment.polyline.length > 0);
+    if (drawableSegments.length === 0) return [];
+
+    return drawableSegments.map((segment) => ({
+      participantId: `${currentParticipant._id}-${segment.toStageId}`,
+      participantName: currentParticipant.name,
+      color: PARTICIPANT_ROUTE_COLOR,
+      polyline: segment.polyline,
+      durationMinutes: segment.durationMinutes,
+      distanceKm: segment.distanceKm,
+    }));
+  }, [itinerary, currentParticipant]);
+
   if (isLoading) {
     return (
       <main className="bg-keria-darker relative flex min-h-screen items-center justify-center">
@@ -130,10 +159,6 @@ export default function EventPage({ params }: { params: Promise<{ id: string }> 
       </main>
     );
   }
-
-  const currentParticipant = participants?.find(
-    (p: Doc<"eventParticipants">) => p._id === currentParticipantId
-  );
 
   const displayStatus = resolveDisplayStatus({
     status: event.status as EventStatus,
@@ -260,6 +285,27 @@ export default function EventPage({ params }: { params: Promise<{ id: string }> 
           </section>
         )}
 
+        {/* Current participant logistics & itinerary */}
+        {currentParticipant && stages && stages.length > 0 ? (
+          <section className="mb-6 space-y-4">
+            <h2 className="border-keria-gold text-keria-muted border-l-2 pl-3 text-xs font-medium uppercase tracking-wider">
+              Votre itinéraire
+            </h2>
+            <ParticipantLogisticsForm
+              participantId={currentParticipant._id}
+              eventId={eventId}
+              initialLocation={currentParticipant.location}
+              initialAddress={currentParticipant.address}
+              initialTransportMode={currentParticipant.transportMode as TransportMode | undefined}
+              hasLogistics={hasLogistics}
+              isCalculating={isCalculating}
+              onSubmit={setLogistics}
+              onCalculate={calculate}
+            />
+            {itinerary ? <ItineraryTimeline itinerary={itinerary} stages={stages} /> : null}
+          </section>
+        ) : null}
+
         {/* Join prompt */}
         {!currentParticipantId && participants && participants.length > 0 && (
           <section className="border-keria-gold/30 bg-keria-gold/5 mb-6 rounded border p-4">
@@ -306,6 +352,8 @@ export default function EventPage({ params }: { params: Promise<{ id: string }> 
           initialCenter={stages?.[0]?.location ?? { lat: 48.8566, lng: 2.3522 }}
           initialZoom={10}
         >
+          {itineraryRoutes.length > 0 && <MapRoute routes={itineraryRoutes} />}
+
           {stages && stages.length >= 2 && (
             <MapStagePath
               stages={stages.map((s: Doc<"eventStages">) => ({

--- a/apps/web/components/event/index.ts
+++ b/apps/web/components/event/index.ts
@@ -6,3 +6,5 @@ export * from "./event-share-card";
 export * from "./event-edit-form";
 export * from "./event-lifecycle-controls";
 export * from "./event-stages-editor";
+export * from "./participant-logistics-form";
+export * from "./itinerary-timeline";

--- a/apps/web/components/event/itinerary-timeline.tsx
+++ b/apps/web/components/event/itinerary-timeline.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { motion } from "framer-motion";
+import type { Doc, Id } from "../../../../convex/_generated/dataModel";
+
+interface ItineraryTimelineProps {
+  itinerary: Doc<"eventItineraries">;
+  stages: Doc<"eventStages">[];
+}
+
+const formatTime = (timestamp: number) =>
+  new Date(timestamp).toLocaleTimeString("fr-FR", {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+
+const formatDuration = (minutes: number) => {
+  const rounded = Math.round(minutes);
+  if (rounded < 60) return `${rounded} min`;
+  const hours = Math.floor(rounded / 60);
+  const rest = rounded % 60;
+  return rest === 0 ? `${hours} h` : `${hours} h ${rest}`;
+};
+
+const isUnavailableSegment = (segment: Doc<"eventItineraries">["segments"][number]) =>
+  segment.durationMinutes === 0 && segment.polyline.length === 0;
+
+export function ItineraryTimeline({ itinerary, stages }: ItineraryTimelineProps) {
+  const stageById = new Map<Id<"eventStages">, Doc<"eventStages">>(
+    stages.map((stage) => [stage._id, stage])
+  );
+
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.3 }}
+      className="border-keria-gold/30 bg-keria-gold/5 space-y-4 rounded border p-4"
+    >
+      <motion.div
+        initial={{ opacity: 0, y: -6 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.3 }}
+        className="border-keria-gold/20 border-b pb-4"
+      >
+        <p className="text-keria-muted text-[10px] uppercase tracking-wider">Départ recommandé</p>
+        <p className="font-display text-keria-gold text-3xl font-bold">
+          {formatTime(itinerary.recommendedDepartureAt)}
+        </p>
+        <div className="text-keria-muted mt-2 flex items-center gap-4 text-[10px] uppercase tracking-wider">
+          <span>{formatDuration(itinerary.totalDurationMinutes)} de trajet</span>
+          <span>{Math.round(itinerary.totalDistanceKm * 10) / 10} km</span>
+        </div>
+      </motion.div>
+
+      <ol className="relative">
+        {itinerary.segments.map((segment, index) => {
+          const stage = stageById.get(segment.toStageId);
+          const isLast = index === itinerary.segments.length - 1;
+          const unavailable = isUnavailableSegment(segment);
+
+          return (
+            <motion.li
+              key={segment.toStageId}
+              initial={{ opacity: 0, x: -10 }}
+              animate={{ opacity: 1, x: 0 }}
+              transition={{ duration: 0.3, delay: 0.1 + index * 0.08 }}
+              className={`relative flex gap-3 ${!isLast ? "pb-5" : ""}`}
+            >
+              {!isLast && (
+                <span className="bg-keria-forest/50 absolute left-[5px] top-4 h-full w-0.5" />
+              )}
+              <span
+                className={`relative z-10 mt-1 h-3 w-3 flex-shrink-0 rounded-full ${
+                  unavailable ? "bg-keria-error" : "bg-keria-gold"
+                }`}
+              />
+              <div className="min-w-0 flex-1">
+                <div className="flex items-baseline justify-between gap-2">
+                  <span className="text-keria-cream truncate text-sm font-medium">
+                    {stage?.name ?? "Étape"}
+                  </span>
+                  {stage && (
+                    <span className="text-keria-gold flex-shrink-0 font-mono text-xs">
+                      {formatTime(stage.scheduledAt)}
+                    </span>
+                  )}
+                </div>
+                {unavailable ? (
+                  <p className="text-keria-error-light mt-0.5 text-[10px] uppercase tracking-wider">
+                    Trajet indisponible
+                  </p>
+                ) : (
+                  <p className="text-keria-muted mt-0.5 text-[10px] uppercase tracking-wider">
+                    {formatDuration(segment.durationMinutes)} •{" "}
+                    {Math.round(segment.distanceKm * 10) / 10} km
+                  </p>
+                )}
+              </div>
+            </motion.li>
+          );
+        })}
+      </ol>
+    </motion.div>
+  );
+}

--- a/apps/web/components/event/participant-logistics-form.tsx
+++ b/apps/web/components/event/participant-logistics-form.tsx
@@ -1,0 +1,334 @@
+"use client";
+
+import { useState } from "react";
+import type { ReactNode } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { Button } from "@meetpoint/ui";
+import { AddressInput } from "@/components/address-input";
+import { useGeolocation } from "@/hooks";
+import type { Coordinates, TransportMode } from "@meetpoint/types";
+import type { Id } from "../../../../convex/_generated/dataModel";
+
+interface ParticipantLogisticsFormProps {
+  participantId: Id<"eventParticipants">;
+  eventId: Id<"events">;
+  initialLocation?: Coordinates;
+  initialAddress?: string;
+  initialTransportMode?: TransportMode;
+  hasLogistics: boolean;
+  isCalculating: boolean;
+  onSubmit: (args: {
+    participantId: Id<"eventParticipants">;
+    location: Coordinates;
+    address?: string;
+    transportMode: TransportMode;
+  }) => Promise<unknown>;
+  onCalculate: (args: {
+    eventId: Id<"events">;
+    eventParticipantId: Id<"eventParticipants">;
+  }) => Promise<unknown>;
+}
+
+const TransportIcons: Record<TransportMode, ReactNode> = {
+  driving: (
+    <svg
+      className="h-5 w-5"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      aria-hidden="true"
+    >
+      <path d="M5 11l1.5-4.5a2 2 0 011.9-1.5h7.2a2 2 0 011.9 1.5L19 11" />
+      <path d="M5 11v6a1 1 0 001 1h1a1 1 0 001-1v-1h8v1a1 1 0 001 1h1a1 1 0 001-1v-6" />
+      <path d="M5 11h14" />
+      <circle cx="7.5" cy="14" r="1" />
+      <circle cx="16.5" cy="14" r="1" />
+    </svg>
+  ),
+  transit: (
+    <svg
+      className="h-5 w-5"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      aria-hidden="true"
+    >
+      <rect x="6" y="3" width="12" height="14" rx="2" />
+      <path d="M6 12h12" />
+      <circle cx="8.5" cy="15" r="1" />
+      <circle cx="15.5" cy="15" r="1" />
+      <path d="M8 20l-1 2m9-2l1 2" />
+    </svg>
+  ),
+  cycling: (
+    <svg
+      className="h-5 w-5"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      aria-hidden="true"
+    >
+      <circle cx="6" cy="17" r="3" />
+      <circle cx="18" cy="17" r="3" />
+      <path d="M6 17l3-7h4l3 7" />
+      <path d="M9 10l3-4" />
+      <circle cx="12" cy="5" r="1" />
+    </svg>
+  ),
+  walking: (
+    <svg
+      className="h-5 w-5"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="4" r="2" />
+      <path d="M12 6v5l3 4" />
+      <path d="M12 11l-3 4" />
+      <path d="M9 21l2-6" />
+      <path d="M15 21l-2-6" />
+    </svg>
+  ),
+};
+
+const TRANSPORT_OPTIONS: { value: TransportMode; label: string }[] = [
+  { value: "driving", label: "Voiture" },
+  { value: "transit", label: "Transports" },
+  { value: "cycling", label: "Vélo" },
+  { value: "walking", label: "À pied" },
+];
+
+export function ParticipantLogisticsForm({
+  participantId,
+  eventId,
+  initialLocation,
+  initialAddress,
+  initialTransportMode,
+  hasLogistics,
+  isCalculating,
+  onSubmit,
+  onCalculate,
+}: ParticipantLogisticsFormProps) {
+  const {
+    coordinates: geoCoordinates,
+    error: geoError,
+    isLoading: geoLoading,
+    requestLocation,
+  } = useGeolocation();
+
+  const [isEditing, setIsEditing] = useState(!hasLogistics);
+  const [location, setLocation] = useState<Coordinates | null>(initialLocation ?? null);
+  const [address, setAddress] = useState<string>(initialAddress ?? "");
+  const [transportMode, setTransportMode] = useState<TransportMode>(
+    initialTransportMode ?? "driving"
+  );
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const effectiveLocation = location ?? geoCoordinates;
+
+  const handleAddressSelect = (coordinates: Coordinates, selectedAddress: string) => {
+    setLocation(coordinates);
+    setAddress(selectedAddress);
+    setError(null);
+  };
+
+  const handleUseGeolocation = () => {
+    requestLocation();
+    setAddress("");
+  };
+
+  const handleSubmit = async () => {
+    setError(null);
+    const submitLocation = location ?? geoCoordinates;
+    if (!submitLocation) {
+      setError("Indiquez votre point de départ");
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      await onSubmit({
+        participantId,
+        location: submitLocation,
+        address: address.trim() || undefined,
+        transportMode,
+      });
+    } catch {
+      setError("Impossible d'enregistrer votre logistique");
+      setIsSaving(false);
+      return;
+    }
+
+    setIsEditing(false);
+    try {
+      await onCalculate({ eventId, eventParticipantId: participantId });
+    } catch {
+      setError("Impossible de calculer votre itinéraire");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  if (!isEditing && hasLogistics) {
+    const selectedOption = TRANSPORT_OPTIONS.find(
+      (option) => option.value === initialTransportMode
+    );
+
+    return (
+      <div className="border-keria-forest/30 bg-keria-forest/10 rounded border p-4">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0 flex-1">
+            <p className="text-keria-muted text-[10px] uppercase tracking-wider">Point de départ</p>
+            <p className="text-keria-cream mt-1 truncate text-sm font-medium">
+              {initialAddress ?? "Position enregistrée"}
+            </p>
+            {selectedOption && (
+              <div className="text-keria-gold mt-2 flex items-center gap-2">
+                {TransportIcons[selectedOption.value]}
+                <span className="text-[10px] uppercase tracking-wider">{selectedOption.label}</span>
+              </div>
+            )}
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            className="text-[10px] uppercase tracking-wider"
+            onClick={() => setIsEditing(true)}
+          >
+            Modifier
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.3 }}
+      className="border-keria-gold/30 bg-keria-gold/5 space-y-4 rounded border p-4"
+    >
+      <div>
+        <label className="text-keria-muted mb-2 block text-[10px] font-medium uppercase tracking-wider">
+          Votre point de départ
+        </label>
+        <AddressInput
+          onSelect={handleAddressSelect}
+          initialValue={address}
+          placeholder="Adresse de départ..."
+        />
+        <button
+          type="button"
+          onClick={handleUseGeolocation}
+          disabled={geoLoading}
+          className="border-keria-forest/30 bg-keria-darker/50 text-keria-muted hover:border-keria-gold/50 hover:text-keria-cream mt-2 flex w-full items-center justify-center gap-2 rounded border p-3 text-xs backdrop-blur-sm transition-all disabled:opacity-50"
+        >
+          {geoLoading ? (
+            <>
+              <div className="border-keria-gold h-4 w-4 animate-spin rounded-full border-2 border-t-transparent" />
+              <span>Localisation...</span>
+            </>
+          ) : (
+            <>
+              <svg
+                className="h-4 w-4"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                aria-hidden="true"
+              >
+                <circle cx="12" cy="12" r="3" />
+                <path d="M12 2v4m0 12v4M2 12h4m12 0h4" />
+              </svg>
+              <span>Ma position</span>
+            </>
+          )}
+        </button>
+        {geoError && <p className="text-keria-error-light mt-2 text-xs">{geoError}</p>}
+        {effectiveLocation && !geoError && (
+          <p className="text-keria-success-light mt-2 flex items-center gap-2 text-[10px]">
+            <svg
+              className="h-3 w-3"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              aria-hidden="true"
+            >
+              <polyline points="20 6 9 17 4 12" />
+            </svg>
+            Position prête
+          </p>
+        )}
+      </div>
+
+      <div>
+        <label className="text-keria-muted mb-2 block text-[10px] font-medium uppercase tracking-wider">
+          Mode de transport
+        </label>
+        <div className="grid grid-cols-2 gap-2">
+          {TRANSPORT_OPTIONS.map((option) => (
+            <motion.button
+              key={option.value}
+              type="button"
+              onClick={() => setTransportMode(option.value)}
+              className={`flex flex-col items-center gap-1.5 rounded border p-3 transition-colors ${
+                transportMode === option.value
+                  ? "border-keria-gold bg-keria-gold/10 text-keria-gold"
+                  : "border-keria-forest/30 bg-keria-darker/30 text-keria-muted hover:border-keria-forest hover:text-keria-cream"
+              }`}
+              whileHover={{ y: -2 }}
+              whileTap={{ scale: 0.95 }}
+            >
+              {TransportIcons[option.value]}
+              <span className="text-[10px] uppercase tracking-wider">{option.label}</span>
+            </motion.button>
+          ))}
+        </div>
+      </div>
+
+      <AnimatePresence>
+        {error && (
+          <motion.div
+            initial={{ opacity: 0, height: 0 }}
+            animate={{ opacity: 1, height: "auto" }}
+            exit={{ opacity: 0, height: 0 }}
+            className="border-keria-error/30 bg-keria-error/10 text-keria-error-light overflow-hidden rounded border p-2 text-xs"
+          >
+            {error}
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      <div className="flex gap-2">
+        {hasLogistics && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="flex-1 text-[10px] uppercase tracking-wider"
+            onClick={() => setIsEditing(false)}
+          >
+            Annuler
+          </Button>
+        )}
+        <Button
+          variant="primary"
+          size="sm"
+          className="flex-1 text-[10px] uppercase tracking-wider"
+          onClick={handleSubmit}
+          isLoading={isSaving || isCalculating}
+        >
+          Calculer mon itinéraire
+        </Button>
+      </div>
+    </motion.div>
+  );
+}

--- a/apps/web/hooks/index.ts
+++ b/apps/web/hooks/index.ts
@@ -3,4 +3,5 @@ export * from "./use-participants";
 export * from "./use-places";
 export * from "./use-geolocation";
 export * from "./use-event";
+export * from "./use-event-itinerary";
 export * from "./use-ai-suggestions";

--- a/apps/web/hooks/use-event-itinerary.ts
+++ b/apps/web/hooks/use-event-itinerary.ts
@@ -1,0 +1,59 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { useQuery, useMutation, useAction } from "convex/react";
+import { api } from "../../../convex/_generated/api";
+import type { Coordinates, TransportMode } from "@meetpoint/types";
+import type { Id } from "../../../convex/_generated/dataModel";
+
+interface SetLogisticsArgs {
+  participantId: Id<"eventParticipants">;
+  location: Coordinates;
+  address?: string;
+  transportMode: TransportMode;
+}
+
+interface CalculateArgs {
+  eventId: Id<"events">;
+  eventParticipantId: Id<"eventParticipants">;
+}
+
+export function useEventItinerary(
+  eventId: Id<"events"> | undefined,
+  eventParticipantId: Id<"eventParticipants"> | null
+) {
+  const setLogisticsMutation = useMutation(api.eventParticipants.setLogistics);
+  const calculateAction = useAction(api.eventRouting.calculateParticipantItinerary);
+
+  const itinerary = useQuery(
+    api.eventRouting.getItinerary,
+    eventParticipantId ? { eventParticipantId } : "skip"
+  );
+
+  const [isCalculating, setIsCalculating] = useState(false);
+
+  const setLogistics = useCallback(
+    (args: SetLogisticsArgs) => setLogisticsMutation(args),
+    [setLogisticsMutation]
+  );
+
+  const calculate = useCallback(
+    async (args: CalculateArgs) => {
+      if (!eventId) throw new Error("Événement introuvable");
+      setIsCalculating(true);
+      try {
+        return await calculateAction(args);
+      } finally {
+        setIsCalculating(false);
+      }
+    },
+    [eventId, calculateAction]
+  );
+
+  return {
+    itinerary: itinerary ?? null,
+    isCalculating,
+    setLogistics,
+    calculate,
+  };
+}


### PR DESCRIPTION
## Summary
- Participants set their position and transport mode (setLogistics) on the event page
- Each participant sees their itinerary (ORS routes drawn on the map) and a recommended departure time per leg

## Changes
- components/event: add participant-logistics-form and itinerary-timeline
- hooks: add use-event-itinerary to compute routes and departure timing
- event/[id]/page: wire logistics form, itinerary timeline, and map routes
- reuse MapRoute, AddressInput, and useGeolocation

## Test plan
- [ ] Open an event, fill in position and transport mode, submit logistics
- [ ] Verify the itinerary route renders on the map
- [ ] Verify the recommended departure time shows per leg in the timeline