### PR TITLE
feat(frontend): suggest and vote on places per event stage

### DIFF
--- a/apps/web/app/event/[id]/page.tsx
+++ b/apps/web/app/event/[id]/page.tsx
@@ -2,12 +2,14 @@
 
 import { use, useState, useEffect, useRef, useMemo } from "react";
 import { useSearchParams } from "next/navigation";
+import { useQuery } from "convex/react";
 import Link from "next/link";
 import { motion } from "framer-motion";
 import { Badge } from "@meetpoint/ui";
 import dynamic from "next/dynamic";
 import { useEvent, useEventStages, useEventParticipants, useEventItinerary } from "@/hooks";
-import { MapStageMarker, MapStagePath, MapRoute } from "@/components/map";
+import { MapStageMarker, MapStagePath, MapRoute, MapMarker } from "@/components/map";
+import { api } from "../../../../../convex/_generated/api";
 import {
   StagesList,
   RSVPButtons,
@@ -18,6 +20,7 @@ import {
   EventStagesEditor,
   ParticipantLogisticsForm,
   ItineraryTimeline,
+  StagePlacesPanel,
 } from "@/components/event";
 import { PageBackground } from "@/components/page-background";
 import {
@@ -67,6 +70,11 @@ export default function EventPage({ params }: { params: Promise<{ id: string }> 
     currentParticipantId
   );
   const [selectedStage, setSelectedStage] = useState<Doc<"eventStages"> | null>(null);
+
+  const selectedStagePlaces = useQuery(
+    api.eventPlaces.listByStage,
+    selectedStage ? { eventStageId: selectedStage._id } : "skip"
+  );
 
   useEffect(() => {
     if (!participants) return;
@@ -268,6 +276,15 @@ export default function EventPage({ params }: { params: Promise<{ id: string }> 
           )}
         </section>
 
+        {/* Suggested places & vote for the selected stage */}
+        {selectedStage && (
+          <StagePlacesPanel
+            key={selectedStage._id}
+            stage={selectedStage}
+            currentParticipantId={currentParticipantId}
+          />
+        )}
+
         {/* Current participant RSVP */}
         {currentParticipant && (
           <section className="border-keria-forest/30 bg-keria-forest/10 mb-6 rounded border p-4">
@@ -373,6 +390,15 @@ export default function EventPage({ params }: { params: Promise<{ id: string }> 
               order={stage.order}
               scheduledAt={stage.scheduledAt}
               onClick={() => handleStageClick(stage)}
+            />
+          ))}
+
+          {selectedStagePlaces?.map((place: Doc<"places">) => (
+            <MapMarker
+              key={place._id}
+              coordinates={place.location}
+              label={place.name}
+              color="gold"
             />
           ))}
         </MapContainer>

--- a/apps/web/components/event/index.ts
+++ b/apps/web/components/event/index.ts
@@ -8,3 +8,5 @@ export * from "./event-lifecycle-controls";
 export * from "./event-stages-editor";
 export * from "./participant-logistics-form";
 export * from "./itinerary-timeline";
+export * from "./stage-place-vote";
+export * from "./stage-places-panel";

--- a/apps/web/components/event/stage-place-vote.tsx
+++ b/apps/web/components/event/stage-place-vote.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+interface StagePlaceVoteProps {
+  placeName: string;
+  score: number;
+  upvotes: number;
+  downvotes: number;
+  currentVote: "up" | "down" | null;
+  canVote: boolean;
+  onVote: (vote: "up" | "down") => void;
+}
+
+export function StagePlaceVote({
+  placeName,
+  score,
+  upvotes,
+  downvotes,
+  currentVote,
+  canVote,
+  onVote,
+}: StagePlaceVoteProps) {
+  return (
+    <div className="flex items-center gap-3">
+      <div className="flex-shrink-0 text-center">
+        <div
+          className={`text-lg font-bold ${
+            score > 0
+              ? "text-keria-success-light"
+              : score < 0
+                ? "text-keria-error-light"
+                : "text-keria-muted"
+          }`}
+        >
+          {score > 0 ? "+" : ""}
+          {score}
+        </div>
+        <div className="text-keria-muted text-xs">
+          {upvotes}↑ {downvotes}↓
+        </div>
+      </div>
+
+      <div className="flex gap-1.5">
+        <motion.button
+          whileTap={canVote ? { scale: 0.9 } : undefined}
+          onClick={() => onVote("up")}
+          disabled={!canVote}
+          aria-label={`Voter pour ${placeName}`}
+          aria-pressed={currentVote === "up"}
+          className={`flex h-9 w-9 items-center justify-center rounded-lg transition-colors disabled:cursor-not-allowed disabled:opacity-40 ${
+            currentVote === "up"
+              ? "bg-keria-success/20 text-keria-success-light ring-keria-success ring-2"
+              : "bg-keria-forest/30 text-keria-cream hover:bg-keria-success/10"
+          }`}
+        >
+          <svg
+            className="h-4 w-4"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            aria-hidden="true"
+          >
+            <path d="M14 9V5a3 3 0 00-3-3l-4 9v11h11.28a2 2 0 002-1.7l1.38-9a2 2 0 00-2-2.3zM7 22H4a2 2 0 01-2-2v-7a2 2 0 012-2h3" />
+          </svg>
+        </motion.button>
+
+        <motion.button
+          whileTap={canVote ? { scale: 0.9 } : undefined}
+          onClick={() => onVote("down")}
+          disabled={!canVote}
+          aria-label={`Voter contre ${placeName}`}
+          aria-pressed={currentVote === "down"}
+          className={`flex h-9 w-9 items-center justify-center rounded-lg transition-colors disabled:cursor-not-allowed disabled:opacity-40 ${
+            currentVote === "down"
+              ? "bg-keria-error/20 text-keria-error-light ring-keria-error ring-2"
+              : "bg-keria-forest/30 text-keria-cream hover:bg-keria-error/10"
+          }`}
+        >
+          <svg
+            className="h-4 w-4"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            aria-hidden="true"
+          >
+            <path d="M10 15v4a3 3 0 003 3l4-9V2H5.72a2 2 0 00-2 1.7l-1.38 9a2 2 0 002 2.3zm7-13h2.67A2.31 2.31 0 0122 4v7a2.31 2.31 0 01-2.33 2H17" />
+          </svg>
+        </motion.button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/event/stage-places-panel.tsx
+++ b/apps/web/components/event/stage-places-panel.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { useState } from "react";
+import { motion } from "framer-motion";
+import { Badge, Button } from "@meetpoint/ui";
+import { useEventPlaces } from "@/hooks";
+import { StagePlaceVote } from "./stage-place-vote";
+import type { Id, Doc } from "../../../../convex/_generated/dataModel";
+
+interface StagePlacesPanelProps {
+  stage: Doc<"eventStages">;
+  currentParticipantId: Id<"eventParticipants"> | null;
+}
+
+interface PlaceRankingItem {
+  place: Doc<"places">;
+  upvotes: number;
+  downvotes: number;
+  score: number;
+}
+
+const CATEGORY_LABELS: Record<string, string> = {
+  restaurant: "Restaurant",
+  cafe: "Café",
+  bar: "Bar",
+  fast_food: "Fast-food",
+  cinema: "Cinéma",
+  park: "Parc",
+  other: "Autre",
+};
+
+const listVariants = {
+  hidden: {},
+  visible: { transition: { staggerChildren: 0.06 } },
+};
+
+const itemVariants = {
+  hidden: { opacity: 0, y: 16 },
+  visible: { opacity: 1, y: 0 },
+};
+
+export function StagePlacesPanel({ stage, currentParticipantId }: StagePlacesPanelProps) {
+  const { ranking, isLoading, isSearching, search, vote, getUserVote } = useEventPlaces(stage._id);
+  const [error, setError] = useState<string | null>(null);
+
+  const canVote = currentParticipantId !== null;
+
+  const handleSearch = async () => {
+    setError(null);
+    try {
+      const result = await search({ eventStageId: stage._id });
+      if (!result.success) {
+        setError(result.error ?? "Erreur de recherche");
+      }
+    } catch (_error) {
+      setError("Erreur de connexion");
+    }
+  };
+
+  const handleVote = async (placeId: Id<"places">, voteValue: "up" | "down") => {
+    if (!currentParticipantId) return;
+    setError(null);
+    try {
+      await vote({
+        eventStageId: stage._id,
+        placeId,
+        eventParticipantId: currentParticipantId,
+        vote: voteValue,
+      });
+    } catch (_error) {
+      setError("Erreur lors du vote");
+    }
+  };
+
+  const hasPlaces = ranking !== undefined && ranking.length > 0;
+
+  return (
+    <motion.section
+      initial={{ opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.25 }}
+      className="border-keria-gold/30 bg-keria-gold/5 mb-6 rounded border p-4"
+    >
+      <div className="mb-3 flex items-start justify-between gap-2">
+        <h2 className="border-keria-gold text-keria-cream border-l-2 pl-3 text-xs font-medium uppercase tracking-wider">
+          Lieux près de {stage.name}
+        </h2>
+        {hasPlaces && <Badge variant="default">{ranking.length}</Badge>}
+      </div>
+
+      <Button
+        size="sm"
+        variant="primary"
+        onClick={handleSearch}
+        isLoading={isSearching}
+        className="w-full"
+      >
+        Rechercher des lieux
+      </Button>
+
+      {error && (
+        <p role="alert" aria-live="assertive" className="text-keria-error-light mt-2 text-xs">
+          {error}
+        </p>
+      )}
+
+      {!canVote && (
+        <p className="text-keria-gold mt-3 text-xs">Rejoignez l'événement pour voter.</p>
+      )}
+
+      <div className="mt-4">
+        {isLoading ? (
+          <p className="text-keria-muted py-4 text-center text-sm">Chargement...</p>
+        ) : hasPlaces ? (
+          <motion.ul
+            className="space-y-2.5"
+            initial="hidden"
+            animate="visible"
+            variants={listVariants}
+          >
+            {ranking.map((item: PlaceRankingItem) => {
+              const { place, score, upvotes, downvotes } = item;
+              const categoryLabel = CATEGORY_LABELS[place.category] ?? "Autre";
+
+              return (
+                <motion.li
+                  key={place._id}
+                  variants={itemVariants}
+                  className="border-keria-forest/30 bg-keria-forest/10 flex items-center justify-between gap-3 rounded-lg border p-3"
+                >
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <span className="text-keria-muted text-[10px] uppercase">
+                        {categoryLabel}
+                      </span>
+                      <span className="text-keria-forest">·</span>
+                      <span className="text-keria-cream truncate font-medium">{place.name}</span>
+                    </div>
+                    <p className="text-keria-muted mt-1 truncate text-xs">{place.address}</p>
+                  </div>
+
+                  <StagePlaceVote
+                    placeName={place.name}
+                    score={score}
+                    upvotes={upvotes}
+                    downvotes={downvotes}
+                    currentVote={getUserVote(place._id, currentParticipantId)}
+                    canVote={canVote}
+                    onVote={(voteValue) => void handleVote(place._id, voteValue)}
+                  />
+                </motion.li>
+              );
+            })}
+          </motion.ul>
+        ) : (
+          <p className="text-keria-muted py-4 text-center text-sm">
+            Aucun lieu pour cette étape. Lancez une recherche pour en suggérer.
+          </p>
+        )}
+      </div>
+    </motion.section>
+  );
+}

--- a/apps/web/hooks/index.ts
+++ b/apps/web/hooks/index.ts
@@ -4,4 +4,5 @@ export * from "./use-places";
 export * from "./use-geolocation";
 export * from "./use-event";
 export * from "./use-event-itinerary";
+export * from "./use-event-places";
 export * from "./use-ai-suggestions";

--- a/apps/web/hooks/use-event-places.ts
+++ b/apps/web/hooks/use-event-places.ts
@@ -1,0 +1,67 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { useQuery, useMutation, useAction } from "convex/react";
+import { api } from "../../../convex/_generated/api";
+import type { Id, Doc } from "../../../convex/_generated/dataModel";
+
+interface SearchForStageArgs {
+  eventStageId: Id<"eventStages">;
+  radiusMeters?: number;
+  categories?: string[];
+  limit?: number;
+}
+
+interface CastVoteArgs {
+  eventStageId: Id<"eventStages">;
+  placeId: Id<"places">;
+  eventParticipantId: Id<"eventParticipants">;
+  vote: "up" | "down";
+}
+
+export function useEventPlaces(eventStageId: Id<"eventStages"> | null) {
+  const ranking = useQuery(
+    api.eventVotes.getStageRanking,
+    eventStageId ? { eventStageId } : "skip"
+  );
+  const votes = useQuery(api.eventVotes.listByStage, eventStageId ? { eventStageId } : "skip");
+
+  const searchAction = useAction(api.eventPlaces.searchForStage);
+  const voteMutation = useMutation(api.eventVotes.cast);
+
+  const [isSearching, setIsSearching] = useState(false);
+
+  const search = useCallback(
+    async (args: SearchForStageArgs) => {
+      setIsSearching(true);
+      try {
+        return await searchAction(args);
+      } finally {
+        setIsSearching(false);
+      }
+    },
+    [searchAction]
+  );
+
+  const vote = useCallback((args: CastVoteArgs) => voteMutation(args), [voteMutation]);
+
+  const getUserVote = useCallback(
+    (placeId: Id<"places">, eventParticipantId: Id<"eventParticipants"> | null) => {
+      if (!eventParticipantId || !votes) return null;
+      const userVote = votes.find(
+        (v: Doc<"votes">) => v.placeId === placeId && v.eventParticipantId === eventParticipantId
+      );
+      return userVote?.vote ?? null;
+    },
+    [votes]
+  );
+
+  return {
+    ranking,
+    isLoading: ranking === undefined,
+    isSearching,
+    search,
+    vote,
+    getUserVote,
+  };
+}


### PR DESCRIPTION
## Summary
- Selecting a stage surfaces real nearby places (Overpass) and lets participants vote
- Up/down votes drive a live ranking, with place markers shown on the map

## Changes
- stage-places-panel: fetch and list suggested places for the selected stage
- stage-place-vote: up/down voting control with real-time ranking
- use-event-places: hook to load and manage place suggestions
- event page: wire panel into stage selection and render place markers

## Test plan
- [ ] Select a stage and confirm nearby places load
- [ ] Vote up/down and verify the ranking updates in real time
- [ ] Confirm place markers appear on the map