### PR TITLE
feat(frontend): add ai itinerary assistant for events

### DIFF
--- a/apps/web/app/event/[id]/page.tsx
+++ b/apps/web/app/event/[id]/page.tsx
@@ -21,6 +21,7 @@ import {
   ParticipantLogisticsForm,
   ItineraryTimeline,
   StagePlacesPanel,
+  ItineraryAssistant,
 } from "@/components/event";
 import { PageBackground } from "@/components/page-background";
 import {
@@ -320,6 +321,13 @@ export default function EventPage({ params }: { params: Promise<{ id: string }> 
               onCalculate={calculate}
             />
             {itinerary ? <ItineraryTimeline itinerary={itinerary} stages={stages} /> : null}
+          </section>
+        ) : null}
+
+        {/* AI itinerary assistant */}
+        {stages && stages.length > 0 ? (
+          <section className="mb-6">
+            <ItineraryAssistant eventId={eventId} />
           </section>
         ) : null}
 

--- a/apps/web/components/event/index.ts
+++ b/apps/web/components/event/index.ts
@@ -10,3 +10,4 @@ export * from "./participant-logistics-form";
 export * from "./itinerary-timeline";
 export * from "./stage-place-vote";
 export * from "./stage-places-panel";
+export * from "./itinerary-assistant";

--- a/apps/web/components/event/itinerary-assistant.tsx
+++ b/apps/web/components/event/itinerary-assistant.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { Button, Card, CardHeader, CardTitle, CardContent, Badge } from "@meetpoint/ui";
+import { useEventAi } from "@/hooks";
+import type { Id } from "../../../../convex/_generated/dataModel";
+import type { ItineraryIdea } from "@/types/ai";
+
+interface ItineraryAssistantProps {
+  eventId: Id<"events">;
+}
+
+const GENERIC_ERROR = "L'assistant n'a pas pu générer de suggestions. Réessayez.";
+
+export function ItineraryAssistant({ eventId }: ItineraryAssistantProps) {
+  const { isEnabled, isSuggesting, suggest } = useEventAi();
+
+  const [description, setDescription] = useState("");
+  const [ideas, setIdeas] = useState<ItineraryIdea[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  if (isEnabled !== true) return null;
+
+  const handleSubmit = async () => {
+    const trimmed = description.trim();
+    if (trimmed.length === 0) return;
+
+    setError(null);
+
+    try {
+      const result = await suggest({ eventId, description: trimmed });
+
+      if (result.success) {
+        setIdeas(result.ideas);
+      } else {
+        setIdeas([]);
+        setError(GENERIC_ERROR);
+      }
+    } catch (_error) {
+      setIdeas([]);
+      setError(GENERIC_ERROR);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-base">Assistant d'itinéraire</CardTitle>
+          <Badge variant="primary" className="text-[10px] uppercase tracking-wider">
+            IA
+          </Badge>
+        </div>
+      </CardHeader>
+
+      <CardContent className="space-y-3">
+        <textarea
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          rows={3}
+          aria-label="Décrivez l'ambiance ou ce que vous voulez pour cette sortie"
+          placeholder="Une sortie conviviale, une pause gourmande entre deux étapes, un peu de temps libre…"
+          className="border-keria-forest/30 bg-keria-darker text-keria-cream placeholder:text-keria-muted focus:border-keria-gold/50 focus:ring-keria-gold/30 w-full resize-none rounded-lg border px-3 py-2 text-sm focus:outline-none focus:ring-2"
+        />
+
+        <motion.div whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }}>
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={handleSubmit}
+            isLoading={isSuggesting}
+            disabled={description.trim().length === 0}
+            className="w-full"
+          >
+            Suggérer des idées
+          </Button>
+        </motion.div>
+
+        {error && (
+          <p role="alert" aria-live="assertive" className="text-keria-error-light text-xs">
+            {error}
+          </p>
+        )}
+
+        <AnimatePresence mode="popLayout">
+          {ideas.length > 0 && (
+            <motion.ul
+              key="itinerary-ideas"
+              className="space-y-3 pt-1"
+              initial="hidden"
+              animate="visible"
+              exit={{ opacity: 0 }}
+              variants={{
+                hidden: {},
+                visible: { transition: { staggerChildren: 0.08 } },
+              }}
+            >
+              {ideas.map((idea, index) => (
+                <motion.li
+                  key={`${idea.title}-${index}`}
+                  variants={{
+                    hidden: { opacity: 0, y: 16 },
+                    visible: { opacity: 1, y: 0 },
+                  }}
+                  className="border-keria-forest/30 bg-keria-forest/10 rounded-lg border p-3"
+                >
+                  <div className="mb-1.5 flex items-center gap-2">
+                    <Badge variant="default" className="text-[10px] uppercase tracking-wider">
+                      {idea.category}
+                    </Badge>
+                  </div>
+                  <h3 className="font-display text-keria-cream font-semibold">{idea.title}</h3>
+                  <p className="text-keria-cream/80 mt-1.5 text-sm">{idea.reason}</p>
+                </motion.li>
+              ))}
+            </motion.ul>
+          )}
+        </AnimatePresence>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/hooks/index.ts
+++ b/apps/web/hooks/index.ts
@@ -6,3 +6,4 @@ export * from "./use-event";
 export * from "./use-event-itinerary";
 export * from "./use-event-places";
 export * from "./use-ai-suggestions";
+export * from "./use-event-ai";

--- a/apps/web/hooks/use-event-ai.ts
+++ b/apps/web/hooks/use-event-ai.ts
@@ -1,0 +1,33 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery, useAction } from "convex/react";
+import { api } from "../../../convex/_generated/api";
+import type { Id } from "../../../convex/_generated/dataModel";
+
+interface SuggestItineraryArgs {
+  eventId: Id<"events">;
+  description: string;
+}
+
+export function useEventAi() {
+  const isEnabled = useQuery(api.ai.isEnabled, {});
+  const suggestItinerary = useAction(api.eventAi.suggestItinerary);
+
+  const [isSuggesting, setIsSuggesting] = useState(false);
+
+  const suggest = async (args: SuggestItineraryArgs) => {
+    setIsSuggesting(true);
+    try {
+      return await suggestItinerary(args);
+    } finally {
+      setIsSuggesting(false);
+    }
+  };
+
+  return {
+    isEnabled,
+    isSuggesting,
+    suggest,
+  };
+}

--- a/apps/web/types/ai.ts
+++ b/apps/web/types/ai.ts
@@ -2,3 +2,9 @@
 // share a single source of truth. Re-exported here to keep the @/types/ai
 // import path stable for existing consumers.
 export type { SuggestedCity, SelectedCity } from "@meetpoint/types";
+
+export interface ItineraryIdea {
+  title: string;
+  category: string;
+  reason: string;
+}

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -9,6 +9,7 @@
  */
 
 import type * as ai from "../ai.js";
+import type * as eventAi from "../eventAi.js";
 import type * as eventParticipants from "../eventParticipants.js";
 import type * as eventPlaces from "../eventPlaces.js";
 import type * as eventRouting from "../eventRouting.js";
@@ -33,6 +34,7 @@ import type {
 
 declare const fullApi: ApiFromModules<{
   ai: typeof ai;
+  eventAi: typeof eventAi;
   eventParticipants: typeof eventParticipants;
   eventPlaces: typeof eventPlaces;
   eventRouting: typeof eventRouting;

--- a/convex/eventAi.ts
+++ b/convex/eventAi.ts
@@ -1,0 +1,204 @@
+import { action } from "./_generated/server";
+import { api } from "./_generated/api";
+import { v } from "convex/values";
+import type { Doc } from "./_generated/dataModel";
+import { DESCRIPTION_MAX } from "./validation";
+
+const ANTHROPIC_API_URL = "https://api.anthropic.com/v1/messages";
+const ANTHROPIC_MODEL = "claude-haiku-4-5";
+const MIN_IDEAS = 3;
+const MAX_IDEAS = 5;
+const MAX_TOKENS = 1024;
+
+type AnthropicContentBlock = {
+  type: string;
+  text: string;
+};
+
+type AnthropicResponse = {
+  content: AnthropicContentBlock[];
+};
+
+type SuggestedIdea = {
+  title: string;
+  category: string;
+  reason: string;
+};
+
+type ParsedAiResponse = {
+  ideas: SuggestedIdea[];
+};
+
+type SuggestItineraryResult = {
+  success: boolean;
+  ideas: SuggestedIdea[];
+  error?: string;
+};
+
+function isValidIdea(value: unknown): value is SuggestedIdea {
+  if (typeof value !== "object" || value === null) return false;
+
+  const idea = value as Record<string, unknown>;
+
+  return (
+    typeof idea.title === "string" &&
+    typeof idea.category === "string" &&
+    typeof idea.reason === "string"
+  );
+}
+
+function sanitizeReason(reason: string): string {
+  return reason
+    .replace(/optimal meeting point/gi, "lieu de rendez-vous")
+    .replace(/meeting point/gi, "lieu de rendez-vous")
+    .replace(/bounding box/gi, "secteur")
+    .replace(/\s*\bcoordinates?\b/gi, "")
+    .replace(/\s*\bcoordonn[ée]es?\b/gi, "")
+    .replace(/\s*\blatitude\b/gi, "")
+    .replace(/\s*\blongitude\b/gi, "")
+    .replace(/\s{2,}/g, " ")
+    .trim();
+}
+
+function formatStageTime(scheduledAt: number): string {
+  return new Date(scheduledAt).toLocaleString("fr-FR", {
+    weekday: "long",
+    day: "numeric",
+    month: "long",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function buildSystemPrompt(): string {
+  return [
+    "You are an itinerary assistant that enriches a multi-stage event for a group.",
+    "Given the ordered stages of an event (names, addresses, times) and a free description of the atmosphere the group wants, suggest concrete ideas to enrich the itinerary.",
+    "Ideas can be breaks, intermediate activities, or timing advice between or around the stages.",
+    "Always answer with a single strict JSON object and nothing else.",
+    'The JSON must have exactly this shape: { "ideas": [{ "title": string, "category": string, "reason": string }] }.',
+    'Write the "title", "category", and "reason" fields in French, addressed to the user.',
+    'The "title" must be a short label, the "category" a single word or short phrase, and the "reason" a single concise sentence.',
+    'The "reason" must never mention technical terms such as coordinates, latitude, longitude, or bounding box.',
+    `Provide between ${MIN_IDEAS} and ${MAX_IDEAS} ideas.`,
+  ].join(" ");
+}
+
+function buildUserPrompt(stages: Doc<"eventStages">[], description: string): string {
+  const stageLines = stages.map((stage, index) => {
+    return `Stage ${index + 1}: ${stage.name} — ${stage.address} — ${formatStageTime(stage.scheduledAt)}`;
+  });
+
+  return [
+    "Event stages in order:",
+    ...stageLines,
+    "",
+    "Desired atmosphere described by the group:",
+    description,
+    "",
+    `Suggest between ${MIN_IDEAS} and ${MAX_IDEAS} concrete ideas to enrich this itinerary.`,
+  ].join("\n");
+}
+
+export const suggestItinerary = action({
+  args: {
+    eventId: v.id("events"),
+    description: v.string(),
+  },
+  handler: async (ctx, args): Promise<SuggestItineraryResult> => {
+    const cleaned = args.description.trim();
+    if (cleaned.length === 0 || cleaned.length > DESCRIPTION_MAX) {
+      return {
+        success: false,
+        ideas: [],
+        error: "Description invalide",
+      };
+    }
+
+    const apiKey = process.env.ANTHROPIC_API_KEY;
+    if (!apiKey) {
+      return {
+        success: false,
+        ideas: [],
+        error: "ANTHROPIC_API_KEY not configured",
+      };
+    }
+
+    const stages = await ctx.runQuery(api.events.getStages, { eventId: args.eventId });
+    const systemPrompt = buildSystemPrompt();
+    const userPrompt = buildUserPrompt(stages, cleaned);
+
+    try {
+      const response = await fetch(ANTHROPIC_API_URL, {
+        method: "POST",
+        headers: {
+          "x-api-key": apiKey,
+          "anthropic-version": "2023-06-01",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          model: ANTHROPIC_MODEL,
+          max_tokens: MAX_TOKENS,
+          system: systemPrompt,
+          messages: [
+            { role: "user", content: userPrompt },
+            { role: "assistant", content: "{" },
+          ],
+        }),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        console.error("Anthropic API error:", errorText);
+        return {
+          success: false,
+          ideas: [],
+          error: "Anthropic API error",
+        };
+      }
+
+      const data: AnthropicResponse = await response.json();
+      const rawText = data.content[0]?.text ?? "";
+      const jsonText = `{${rawText}`;
+
+      let parsed: ParsedAiResponse;
+      try {
+        const candidate = JSON.parse(jsonText) as Record<string, unknown>;
+        const ideas = Array.isArray(candidate.ideas) ? candidate.ideas.filter(isValidIdea) : [];
+        parsed = { ideas };
+      } catch {
+        return {
+          success: false,
+          ideas: [],
+          error: "Invalid AI response",
+        };
+      }
+
+      const ideas: SuggestedIdea[] = parsed.ideas.slice(0, MAX_IDEAS).map((idea) => ({
+        title: idea.title,
+        category: idea.category,
+        reason: sanitizeReason(idea.reason),
+      }));
+
+      if (ideas.length < MIN_IDEAS) {
+        return {
+          success: false,
+          ideas: [],
+          error: "Invalid AI response",
+        };
+      }
+
+      return {
+        success: true,
+        ideas,
+      };
+    } catch (error) {
+      console.error("Error suggesting itinerary with Anthropic:", error);
+      return {
+        success: false,
+        ideas: [],
+        error: error instanceof Error ? error.message : "Unknown error",
+      };
+    }
+  },
+});


### PR DESCRIPTION
## Summary
- add an assistant that turns event stages plus a free-text description into 3-5 suggestions to enrich the itinerary
- final PR of the Event redesign series

## Changes
- convex/eventAi.ts: backend action mirroring the meet-mode cities assistant, using the Claude Haiku model
- apps/web: use-event-ai hook and itinerary-assistant component, wired into the event detail page

## Test plan
- [ ] open an event with stages, enter a description, request suggestions
- [ ] verify graceful degradation when no api key is configured (gated by api.ai.isEnabled)